### PR TITLE
Raise arcanist usage exceptions on errors

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/conduit/ArcanistClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/ArcanistClient.java
@@ -76,7 +76,8 @@ public class ArcanistClient {
         return command.stdout(stderr).stderr(stderr).join();
     }
 
-    public JSONObject parseConduit(Launcher.ProcStarter starter, PrintStream stderr) throws IOException, InterruptedException {
+    public JSONObject parseConduit(Launcher.ProcStarter starter, PrintStream stderr)
+            throws ArcanistUsageException, IOException, InterruptedException {
         Launcher.ProcStarter command = this.getCommand(starter);
         ByteArrayOutputStream stdoutBuffer = new ByteArrayOutputStream();
 
@@ -86,15 +87,17 @@ public class ArcanistClient {
                 join();
 
         if (returnCode != 0) {
+            String errorMessage = stdoutBuffer.toString();
             stderr.println("[arcanist] returned non-zero exit code " + returnCode);
-            stderr.println("[arcanist] output: " + stdoutBuffer.toString());
+            stderr.println("[arcanist] output: " + errorMessage);
+            throw new ArcanistUsageException(errorMessage);
         }
 
         JsonSlurper jsonParser = new JsonSlurper();
         try {
             return (JSONObject) jsonParser.parseText(stdoutBuffer.toString());
         } catch(net.sf.json.JSONException e) {
-            stderr.println("[phabricator] Unable to parse JSON from response: " + stdoutBuffer.toString());
+            stderr.println("[arcanist] Unable to parse JSON from response: " + stdoutBuffer.toString());
             throw e;
         }
     }

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/ArcanistUsageException.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/ArcanistUsageException.java
@@ -1,0 +1,28 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+package com.uber.jenkins.phabricator.conduit;
+
+public class ArcanistUsageException extends Exception {
+    public ArcanistUsageException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/Differential.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/Differential.java
@@ -39,7 +39,7 @@ public class Differential {
     private final String conduitToken;
     private final String arcPath;
 
-    public Differential(String diffID, LauncherFactory launcher, String conduitToken, String arcPath) throws IOException, InterruptedException {
+    public Differential(String diffID, LauncherFactory launcher, String conduitToken, String arcPath) throws IOException, InterruptedException, ArcanistUsageException {
         this.conduitToken = conduitToken;
         this.arcPath = arcPath;
         this.launcher = launcher;
@@ -72,7 +72,7 @@ public class Differential {
      * @throws IOException
      * @throws InterruptedException
      */
-    public void harbormaster(String phid, boolean pass) throws IOException, InterruptedException {
+    public void harbormaster(String phid, boolean pass) throws IOException, InterruptedException, ArcanistUsageException {
         Map params = new HashMap<String, String>();
         params.put("type", pass ? "pass" : "fail");
         params.put("buildTargetPHID", phid);
@@ -80,7 +80,7 @@ public class Differential {
         this.callConduit("harbormaster.sendmessage", params);
     }
 
-    private JSONObject callConduit(String methodName, Map<String, String> params) throws IOException, InterruptedException {
+    private JSONObject callConduit(String methodName, Map<String, String> params) throws IOException, InterruptedException, ArcanistUsageException {
         ArcanistClient arc = new ArcanistClient(this.arcPath, "call-conduit", params, this.conduitToken, methodName);
         return arc.parseConduit(this.launcher.launch(), this.launcher.getStderr());
     }
@@ -91,7 +91,7 @@ public class Differential {
      * @param silent whether or not to trigger an email
      * @param action phabricator comment action, e.g. 'resign', 'reject', 'none'
      */
-    public JSONObject postComment(String message, boolean silent, String action) throws IOException, InterruptedException {
+    public JSONObject postComment(String message, boolean silent, String action) throws IOException, InterruptedException, ArcanistUsageException {
         Map params = new HashMap<String, String>();
         params.put("revision_id", this.getRevisionID(false));
         params.put("action", action);
@@ -101,7 +101,7 @@ public class Differential {
         return this.callConduit("differential.createcomment", params);
     }
 
-    public JSONObject postComment(String message) throws IOException, InterruptedException {
+    public JSONObject postComment(String message) throws IOException, InterruptedException, ArcanistUsageException {
         return postComment(message, true, "none");
     }
 


### PR DESCRIPTION
Problems like #19 are misleading because it looks like a JSON parsing
error, when we know there is no JSON to parse. Make the callers deal
with the errors and print a useful error message as to why things are
failing.

@jjx @lavahot