### PR TITLE
Add minimal integration test

### DIFF
--- a/src/test/java/com/uber/jenkins/phabricator/BuildIntegrationTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/BuildIntegrationTest.java
@@ -1,0 +1,46 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.jenkins.phabricator;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class BuildIntegrationTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    protected FreeStyleProject p;
+
+    protected void assertSuccessfulBuild(Result result) {
+        assertTrue(result.isCompleteBuild());
+        assertTrue(result.isBetterOrEqualTo(Result.SUCCESS));
+    }
+
+    protected FreeStyleProject createProject() throws IOException {
+        return j.createFreeStyleProject();
+    }
+}

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
@@ -1,0 +1,52 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.jenkins.phabricator;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
+    private PhabricatorBuildWrapper wrapper;
+
+    @Before
+    public void setUp() throws IOException {
+        p = createProject();
+        wrapper = new PhabricatorBuildWrapper(
+                false,
+                false,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testNoParameterBuild() throws Exception {
+        p.getBuildWrappersList().add(wrapper);
+
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        Result result = build.getResult();
+        assertSuccessfulBuild(result);
+    }
+}

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -1,0 +1,54 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.jenkins.phabricator;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class PhabricatorNotifierTest extends BuildIntegrationTest {
+    private PhabricatorNotifier notifier;
+
+    @Before
+    public void setUp() throws IOException {
+        p = createProject();
+        notifier = new PhabricatorNotifier(
+                false,
+                true,
+                ".phabricator-comment",
+                "1000",
+                false
+        );
+    }
+
+    @Test
+    public void testNoParametersBuild() throws Exception {
+        p.getPublishersList().add(notifier);
+
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        Result result = build.getResult();
+
+        assertSuccessfulBuild(result);
+    }
+}


### PR DESCRIPTION
This tests the no-parameter case of both the build wrapper and the
notifier (publisher). It is not very useful yet, but lays the groundwork
for testing real flows.