### PR TITLE
Refactor PhabricatorNotifier comment builder

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
+++ b/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
@@ -1,0 +1,158 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.jenkins.phabricator;
+
+import com.uber.jenkins.phabricator.utils.CommonUtils;
+import com.uber.jenkins.phabricator.utils.Logger;
+import hudson.model.Result;
+import hudson.plugins.cobertura.Ratio;
+import hudson.plugins.cobertura.targets.CoverageMetric;
+import hudson.plugins.cobertura.targets.CoverageResult;
+
+public class CommentBuilder {
+    private static final String UBERALLS_TAG = "uberalls";
+    private final Logger logger;
+    private final CoverageResult currentCoverage;
+    private final StringBuilder comment;
+    private final String buildURL;
+    private final Result result;
+
+    public CommentBuilder(Logger logger, Result result, CoverageResult currentCoverage, String buildURL) {
+        this.logger = logger;
+        this.result = result;
+        this.currentCoverage = currentCoverage;
+        this.buildURL = buildURL;
+        this.comment = new StringBuilder();
+    }
+
+    /**
+     * Get the final comment to post to Phabricator
+     * @return
+     */
+    public String getComment() {
+        return comment.toString();
+    }
+
+    /**
+     * Determine whether to attempt to process coverage
+     * @return
+     */
+    public boolean hasCoverageAvailable() {
+        if (currentCoverage == null) {
+            return false;
+        }
+
+        Ratio lineCoverage = currentCoverage.getCoverage(CoverageMetric.LINE);
+        return lineCoverage != null;
+    }
+
+    /**
+     * Query uberalls for parent coverage and add appropriate comment
+     * @param parentCoverage the parent coverage returned from uberalls
+     * @param branchName the name of the current branch
+     */
+    public void processParentCoverage(CodeCoverageMetrics parentCoverage, String branchName) {
+        if (parentCoverage == null) {
+            logger.info(UBERALLS_TAG, "unable to find coverage for parent commit");
+            return;
+        }
+
+        Ratio lineCoverage = currentCoverage.getCoverage(CoverageMetric.LINE);
+        Float lineCoveragePercent = lineCoverage.getPercentageFloat();
+
+        logger.info(UBERALLS_TAG, "line coverage: " + lineCoveragePercent);
+        logger.info(UBERALLS_TAG, "found parent coverage as " + parentCoverage.getLineCoveragePercent());
+
+        float coverageDelta = lineCoveragePercent - parentCoverage.getLineCoveragePercent();
+
+        String coverageDeltaDisplay = String.format("%.3f", coverageDelta);
+        String lineCoverageDisplay = String.format("%.3f", lineCoveragePercent);
+
+        if (coverageDelta > 0) {
+            comment.append("Coverage increased (+" + coverageDeltaDisplay + "%) to " + lineCoverageDisplay + "%");
+        } else if (coverageDelta < 0) {
+            comment.append("Coverage decreased (" + coverageDeltaDisplay + "%) to " + lineCoverageDisplay + "%");
+        } else {
+            comment.append("Coverage remained the same (" + lineCoverageDisplay + "%)");
+        }
+
+        comment.append(" when pulling **" + branchName + "** into ");
+        comment.append(parentCoverage.getSha1().substring(0, 7));
+        comment.append(". See " + buildURL + "cobertura for the coverage report");
+    }
+
+    public void processBuildResult(boolean commentOnSuccess, boolean commentWithConsoleLinkOnFailure, boolean runHarbormaster) {
+        if (result == result.SUCCESS) {
+            if (comment.length() == 0 && (commentOnSuccess || !runHarbormaster)) {
+                comment.append("Build is green");
+            }
+        } else if (result == Result.UNSTABLE) {
+            comment.append("Build is unstable");
+        } else if (result == Result.FAILURE) {
+            if (!runHarbormaster || commentWithConsoleLinkOnFailure) {
+                comment.append("Build has FAILED");
+            }
+        } else if (result == Result.ABORTED) {
+            comment.append("Build was aborted");
+        } else {
+            logger.info(UBERALLS_TAG, "Unknown build status " + result.toString());
+        }
+    }
+
+    /**
+     * Add user-defined content via a .phabricator-comment file
+     * @param customComment the contents of the file
+     */
+    public void addUserComment(String customComment) {
+        if (CommonUtils.isBlank(customComment)) {
+            return;
+        }
+
+        // Ensure we separate previous parts of the comment with newlines
+        if (hasComment()) {
+            comment.append("\n\n");
+        }
+        comment.append(String.format("```\n%s\n```\n\n", customComment));
+    }
+
+    /**
+     * Determine if there exists a comment already
+     * @return
+     */
+    public boolean hasComment() {
+        return comment.length() > 0;
+    }
+
+    /**
+     * Add a build link to the comment
+     */
+    public void addBuildLink() {
+        comment.append(String.format(" %s for more details.", buildURL));
+    }
+
+    /**
+     * Add a build failure message to the comment
+     */
+    public void addBuildFailureMessage() {
+        comment.append(String.format("\n\nLink to build: %s", buildURL));
+        comment.append(String.format("\nSee console output for more information: %sconsole", buildURL));
+    }
+}

--- a/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
+++ b/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
@@ -56,12 +56,7 @@ public class CommentBuilder {
      * @return
      */
     public boolean hasCoverageAvailable() {
-        if (currentCoverage == null) {
-            return false;
-        }
-
-        Ratio lineCoverage = currentCoverage.getCoverage(CoverageMetric.LINE);
-        return lineCoverage != null;
+        return currentCoverage != null && currentCoverage.getCoverage(CoverageMetric.LINE) != null;
     }
 
     /**

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -127,9 +127,10 @@ public class PhabricatorNotifier extends Notifier {
         String phid = environment.get(PhabricatorPlugin.PHID_FIELD);
 
         boolean runHarbormaster = !CommonUtils.isBlank(phid);
-        boolean harbormasterSuccess = false;
+        Result buildResult = build.getResult();
+        boolean harbormasterSuccess = buildResult.isBetterOrEqualTo(Result.SUCCESS);
 
-        CommentBuilder commenter = new CommentBuilder(logger, build.getResult(), coverage, environment.get("BUILD_URL"));
+        CommentBuilder commenter = new CommentBuilder(logger, buildResult, coverage, environment.get("BUILD_URL"));
 
         // First add in info about the change in coverage, if applicable
         if (commenter.hasCoverageAvailable()) {
@@ -140,10 +141,6 @@ public class PhabricatorNotifier extends Notifier {
             }
         } else {
             logger.info("uberalls", "no line coverage found, skipping...");
-        }
-
-        if (build.getResult().isBetterOrEqualTo(Result.SUCCESS)) {
-            harbormasterSuccess = true;
         }
 
         // Add in comments about the build result

--- a/src/test/java/com/uber/jenkins/phabricator/CommentBuilderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/CommentBuilderTest.java
@@ -1,0 +1,196 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.jenkins.phabricator;
+
+import com.uber.jenkins.phabricator.utils.Logger;
+import com.uber.jenkins.phabricator.utils.TestUtils;
+import hudson.model.Result;
+import hudson.plugins.cobertura.targets.CoverageResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class CommentBuilderTest {
+    private static final Logger logger = new Logger(System.out);
+    private static final String FAKE_BUILD_URL = "http://example.com/job/123";
+    private static final String FAKE_BRANCH_NAME = "oober-is-great";
+
+    private CommentBuilder commenter;
+
+    @Before
+    public void setUp() {
+        commenter = createCommenter(Result.SUCCESS, TestUtils.getDefaultCoverageResult());
+    }
+
+    @Test
+    public void testHasCoverageAvailable() {
+        assertTrue(commenter.hasCoverageAvailable());
+    }
+
+    @Test
+    public void testHasNoCoverageAvailable() {
+        CommentBuilder commenter = createCommenter(Result.SUCCESS, null);
+        assertFalse(commenter.hasCoverageAvailable());
+    }
+
+    @Test
+    public void testHasNoLineCoverage() {
+        CommentBuilder commenter = createCommenter(Result.SUCCESS, TestUtils.getEmptyCoverageResult());
+        assertFalse(commenter.hasCoverageAvailable());
+    }
+
+    @Test
+    public void testProcessParentWithNullResult() {
+        commenter.processParentCoverage(null, FAKE_BRANCH_NAME);
+        assertFalse(commenter.hasComment());
+    }
+
+    @Test
+    public void testProcessParentWithMatchingCoverage() {
+        commenter.processParentCoverage(TestUtils.getDefaultCodeCoverageMetrics(), FAKE_BRANCH_NAME);
+        String comment = commenter.getComment();
+
+        assertTrue(comment.contains("remained the same"));
+    }
+
+    @Test
+    public void testProcessParentWithIncreasedCoverage() {
+        CodeCoverageMetrics parent = TestUtils.getCodeCoverageMetrics(
+                TestUtils.TEST_SHA,
+                100.0f,
+                100.0f,
+                100.0f,
+                100.0f,
+                90.0f,
+                90.0f
+        );
+        commenter.processParentCoverage(parent, FAKE_BRANCH_NAME);
+        String comment = commenter.getComment();
+
+        assertTrue(comment.contains("increased (+10.000%)"));
+        assertTrue(
+                "comment contains branch name",
+                comment.contains(FAKE_BRANCH_NAME)
+        );
+    }
+
+    @Test
+    public void testProcessWithDecrease() {
+        CoverageResult fiftyPercentDrop = TestUtils.getCoverageResult(1.0f, 1.0f, 1.0f, 1.0f, 0.5f);
+        CommentBuilder commenter = createCommenter(Result.SUCCESS, fiftyPercentDrop);
+        commenter.processParentCoverage(TestUtils.getDefaultCodeCoverageMetrics(), FAKE_BRANCH_NAME);
+        String comment = commenter.getComment();
+
+        assertTrue(comment.contains("decreased (-50.000%)"));
+    }
+
+    @Test
+    public void testProcessBuildResultSuccess() {
+        commenter.processBuildResult(false, false, true);
+        assertTrue(
+                "no message expected for successful builds unless asked for",
+                commenter.getComment().length() == 0
+        );
+    }
+
+    @Test
+    public void testProcessBuildResultSuccessWithComment() {
+        commenter.processBuildResult(true, false, false);
+        assertEquals("Build is green", commenter.getComment());
+    }
+
+    @Test
+    public void testProcessBuildResultUnstable() {
+        CommentBuilder commenter = createCommenter(Result.UNSTABLE, null);
+        commenter.processBuildResult(true, false, false);
+        assertEquals("Build is unstable", commenter.getComment());
+    }
+
+    @Test
+    public void testProcessBuildResultUnknownStatus() {
+        CommentBuilder commenter = createCommenter(Result.NOT_BUILT, null);
+        commenter.processBuildResult(true, false, false);
+        assertFalse(commenter.hasComment());
+    }
+
+    @Test
+    public void testProcessBuildResultWithFailureMessage() {
+        CommentBuilder commenter = createCommenter(Result.FAILURE, null);
+        commenter.processBuildResult(false, true, false);
+        assertEquals("Build has FAILED", commenter.getComment());
+    }
+
+    @Test
+    public void testProcessBuildResultWithoutFailureMessage() {
+        CommentBuilder commenter = createCommenter(Result.FAILURE, null);
+        commenter.processBuildResult(false, false, true);
+        assertEquals(0, commenter.getComment().length());
+    }
+
+    @Test
+    public void testProcessBuildResultAborted() {
+        CommentBuilder commenter = createCommenter(Result.ABORTED, null);
+        commenter.processBuildResult(false, false, false);
+        assertEquals("Build was aborted", commenter.getComment());
+    }
+
+    @Test
+    public void testAddUserComment() {
+        commenter.addUserComment("hello, world");
+        assertEquals("```\nhello, world\n```\n\n", commenter.getComment());
+    }
+
+    @Test
+    public void testAddUserCommentWithStatus() {
+        commenter.processBuildResult(false, false, false);
+        commenter.addUserComment("hello, world");
+        assertEquals("Build is green\n\n```\nhello, world\n```\n\n", commenter.getComment());
+    }
+
+    @Test
+    public void testAddEmptyComment() {
+        commenter.addUserComment("");
+        assertFalse(commenter.hasComment());
+    }
+
+    @Test
+    public void testAddBuildLink() {
+        commenter.addBuildLink();
+        String comment = commenter.getComment();
+        assertTrue(comment.contains("for more details"));
+        assertTrue(comment.contains(FAKE_BUILD_URL));
+    }
+
+    @Test
+    public void testAddBuildFailureMessage() {
+        commenter.addBuildFailureMessage();
+        String comment = commenter.getComment();
+        assertTrue(comment.contains("See console output"));
+        assertTrue(comment.contains("Link to build"));
+    }
+
+    private CommentBuilder createCommenter(Result result, CoverageResult coverage) {
+        return new CommentBuilder(logger, result, coverage, FAKE_BUILD_URL);
+    }
+}

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -101,7 +101,13 @@ public class TestUtils {
     }
 
     public static CoverageResult getDefaultCoverageResult() {
-        return getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 100.0f);
+        return getCoverageResult(1.0f, 1.0f, 1.0f, 1.0f, 1.0f);
+    }
+
+    public static CoverageResult getEmptyCoverageResult() {
+        CoverageResult coverageResult = mock(CoverageResult.class);
+        setCoverage(coverageResult, CoverageMetric.LINE, null);
+        return coverageResult;
     }
 
     public static JSONObject getJSONFromFile(Class<?> klass, String filename) throws IOException {


### PR DESCRIPTION
Instead of having one heaping class that's responsible for a bunch of
business logic, breaking out the comment building and code coverage
comparison into a self-contained class that is easier to test and understand.

Future refactors will break down the Notifier even further, but this is
one atomic piece of work that can go in.

Additionally, fixed a bug in the TestUtils default coverage data, which
was off by 100x for cobertura results (since cobertura the plugin
returns them as floats from 0-1)