### PR TITLE
Add unit test for CodeCoverageMetrics

### DIFF
--- a/src/test/java/com/uber/jenkins/phabricator/CodeCoverageMetricsTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/CodeCoverageMetricsTest.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.jenkins.phabricator;
+
+import com.uber.jenkins.phabricator.utils.TestUtils;
+import hudson.plugins.cobertura.targets.CoverageResult;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CodeCoverageMetricsTest {
+    @Test
+    public void testInstantiateFromCoverageResult() {
+        CoverageResult result = TestUtils.getDefaultCoverageResult();
+        CodeCoverageMetrics metrics = new CodeCoverageMetrics(result);
+
+        assertEquals(100.0f, metrics.getPackageCoveragePercent(), 0);
+        assertEquals(100.0f, metrics.getFilesCoveragePercent(), 0);
+        assertEquals(100.0f, metrics.getClassesCoveragePercent(), 0);
+        assertEquals(100.0f, metrics.getMethodCoveragePercent(), 0);
+        assertEquals(100.0f, metrics.getLineCoveragePercent(), 0);
+        assertEquals(-1f, metrics.getConditionalCoveragePercent(), 0);
+    }
+
+    @Test
+    public void testInstantiateFromNullResult() {
+        CodeCoverageMetrics metrics = new CodeCoverageMetrics(null);
+        assertEquals(-1f, metrics.getLineCoveragePercent(), 0);
+    }
+}


### PR DESCRIPTION
Really just trolling for coverage at this point, but I noticed a large
amount of uncovered code in here which was easy to knock out.