### PR TITLE
Add configuration round-trip testing

### DIFF
--- a/phabricator-plugin.iml
+++ b/phabricator-plugin.iml
@@ -124,8 +124,9 @@
     <orderEntry type="library" name="Maven: net.java.dev.jna:jna:3.2.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:2.0.23-beta" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:0.6.11" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hamcrest:hamcrest-core:1.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:2.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-library:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.main:jenkins-war:war:1.597" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci.main:jenkins-core:1.597" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci.plugins.icon-shim:icon-set:1.0.5" level="project" />
@@ -264,7 +265,6 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci:test-annotations:1.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jvnet.mock-javamail:mock-javamail:1.7" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: junit:junit:4.11" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-library:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci:htmlunit:2.6-jenkins-6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jvnet.hudson:htmlunit-core-js:2.6-hudson-1" level="project" />
     <orderEntry type="library" name="Maven: xerces:xercesImpl:2.9.1" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -65,16 +65,29 @@
     </dependency>
 
     <dependency>
-        <groupId>net.java.dev.jna</groupId>
-        <artifactId>jna</artifactId>
-        <version>3.2.2</version>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>3.2.2</version>
     </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <scope>test</scope>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.0.23-beta</version>
+    </dependency>
+    <dependency>
+      <scope>test</scope>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+    </dependency>
+    <dependency>
+      <scope>test</scope>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
     </dependency>
   </dependencies>
 

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
@@ -49,4 +49,15 @@ public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
         Result result = build.getResult();
         assertSuccessfulBuild(result);
     }
+
+    @Test
+    public void testRoundTripConfiguration() throws Exception {
+        p.getBuildWrappersList().add(wrapper);
+
+        j.submit(j.createWebClient().getPage(p, "configure").getFormByName("config"));
+
+        PhabricatorBuildWrapper after = p.getBuildWrappersList().get(PhabricatorBuildWrapper.class);
+        j.assertEqualBeans(wrapper, after,
+                "createCommit,applyToMaster,showBuildStartedMessage,uberDotArcanist");
+    }
 }

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -51,4 +51,15 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
 
         assertSuccessfulBuild(result);
     }
+
+    @Test
+    public void testRoundTripConfiguration() throws Exception {
+        p.getPublishersList().add(notifier);
+
+        j.submit(j.createWebClient().getPage(p, "configure").getFormByName("config"));
+
+        PhabricatorNotifier after = p.getPublishersList().get(PhabricatorNotifier.class);
+        j.assertEqualBeans(notifier, after,
+                "commentOnSuccess,uberallsEnabled,commentWithConsoleLinkOnFailure,commentFile");
+    }
 }


### PR DESCRIPTION
This verifies that our descriptors are properly configured and that the
getters/setters round-trip through the bean.

https://wiki.jenkins-ci.org/display/JENKINS/Unit+Test#UnitTest-Configurationroundtriptesting

Had to add a hamcrest dependency to get the newer (1.3) matchers.