### PR TITLE
Remove unused JNA dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,6 @@
     </dependency>
 
     <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna</artifactId>
-      <version>3.2.2</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
       <version>1.22</version>


### PR DESCRIPTION
Fixes #61

@cburroughs -- I can't actually remember why this got in here, since we scrubbed history before open sourcing, but it does appear unused.