### PR TITLE
qualify log statements with plugin name

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/utils/Logger.java
+++ b/src/main/java/com/uber/jenkins/phabricator/utils/Logger.java
@@ -26,7 +26,7 @@ import java.io.PrintStream;
  * Logger utility.
  */
 public class Logger {
-    private static final String LOG_FORMAT = "[%s] %s";
+    private static final String LOG_FORMAT = "[phabricator:%s] %s";
 
     private final PrintStream stream;
 

--- a/src/test/java/com/uber/jenkins/phabricator/utils/LoggerTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/LoggerTest.java
@@ -47,7 +47,7 @@ public class LoggerTest {
         String message = "This is a great plugin!";
 
         logger.info(tag, message);
-        assertEquals("[phabricator-jenkins] This is a great plugin!\n", byteArrayOutputStream.toString());
+        assertEquals("[phabricator:phabricator-jenkins] This is a great plugin!\n", byteArrayOutputStream.toString());
     }
 
     @Test
@@ -56,6 +56,6 @@ public class LoggerTest {
         String message = "This is a great comic";
 
         logger.info(tag, message);
-        assertEquals("[a-softer-world] This is a great comic\n", byteArrayOutputStream.toString());
+        assertEquals("[phabricator:a-softer-world] This is a great comic\n", byteArrayOutputStream.toString());
     }
 }


### PR DESCRIPTION
This is (I think) less confusing than `[uberalls]` and
`[comment-file]` mysteriously showing up in build logs.