### PR TITLE
Move all conduit invocations to JSONObject

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClient.java
@@ -41,7 +41,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class ConduitAPIClient {
     private static final String API_TOKEN_KEY = "token";

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClient.java
@@ -58,20 +58,6 @@ public class ConduitAPIClient {
     /**
      * Call the conduit API of Phabricator
      * @param action Name of the API call
-     * @param data The data to send to Harbormaster
-     * @return The result as a JSONObject
-     * @throws IOException If there was a problem reading the response
-     * @throws ConduitAPIException If there was an error calling conduit
-     */
-    public JSONObject perform(String action, Map<String, String> data) throws IOException, ConduitAPIException {
-        JSONObject params = new JSONObject();
-        params.putAll(data);
-        return perform(action, params);
-    }
-
-    /**
-     * Call the conduit API of Phabricator
-     * @param action Name of the API call
      * @param params The data to send to Harbormaster
      * @return The result as a JSONObject
      * @throws IOException If there was a problem reading the response

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClient.java
@@ -87,20 +87,6 @@ public class ConduitAPIClient {
     /**
      * Post a URL-encoded "params" key with a JSON-encoded body as per the Conduit API
      * @param action The name of the Conduit method
-     * @param data The data to be sent to the Conduit method
-     * @return The request to perform
-     * @throws UnsupportedEncodingException when the POST data can't be encoded
-     * @throws ConduitAPIException when the conduit URL is misconfigured
-     */
-    public HttpUriRequest createRequest(String action, Map<String, String> data) throws UnsupportedEncodingException, ConduitAPIException {
-        JSONObject params = new JSONObject();
-        params.putAll(data);
-        return createRequest(action, params);
-    }
-
-    /**
-     * Post a URL-encoded "params" key with a JSON-encoded body as per the Conduit API
-     * @param action The name of the Conduit method
      * @param params The data to be sent to the Conduit method
      * @return The request to perform
      * @throws UnsupportedEncodingException when the POST data can't be encoded

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/DifferentialClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/DifferentialClient.java
@@ -24,8 +24,6 @@ import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * DifferentialClient handles all interaction with conduit/arc for differentials
@@ -50,11 +48,11 @@ public class DifferentialClient {
      * @throws ConduitAPIException if any error is experienced talking to Conduit
      */
     public JSONObject postComment(String revisionID, String message, boolean silent, String action) throws IOException, ConduitAPIException {
-        Map params = new HashMap<String, String>();
-        params.put("revision_id", revisionID);
-        params.put("action", action);
-        params.put("message", message);
-        params.put("silent", silent);
+        JSONObject params = new JSONObject();
+        params.element("revision_id", revisionID)
+            .element("action", action)
+            .element("message", message)
+            .element("silent", silent);
 
         return this.callConduit("differential.createcomment", params);
     }
@@ -66,8 +64,7 @@ public class DifferentialClient {
      * @throws ConduitAPIException if any error is experienced talking to Conduit
      */
     public JSONObject fetchDiff() throws IOException, ConduitAPIException {
-        Map params = new HashMap<String, String>();
-        params.put("ids", new String[]{diffID});
+        JSONObject params = new JSONObject().element("ids", new String[]{diffID});
         JSONObject query = this.callConduit("differential.querydiffs", params);
         JSONObject response;
         try {
@@ -99,10 +96,9 @@ public class DifferentialClient {
      * @throws ConduitAPIException if any error is experienced talking to Conduit
      */
     public JSONObject sendHarbormasterMessage(String phid, boolean pass) throws ConduitAPIException, IOException {
-        Map params = new HashMap<String, String>();
-        params.put("type", pass ? "pass" : "fail");
-        params.put("buildTargetPHID", phid);
-
+        JSONObject params = new JSONObject();
+        params.element("type", pass ? "pass" : "fail")
+                .element("buildTargetPHID", phid);
         return this.callConduit("harbormaster.sendmessage", params);
     }
 
@@ -115,15 +111,17 @@ public class DifferentialClient {
      * @throws ConduitAPIException if any error is experienced talking to Conduit
      */
     public JSONObject sendHarbormasterUri(String phid, String buildUri) throws ConduitAPIException, IOException {
-        Map params = new HashMap<String, String>();
-        params.put("buildTargetPHID", phid);
-        params.put("artifactKey", "jenkins.uri");
-        params.put("artifactType", "uri");
         JSONObject artifactData = new JSONObject();
         artifactData = artifactData.element("uri", buildUri)
-            .element("name", "Jenkins")
-            .element("ui.external", true);
-        params.put("artifactData", artifactData);
+                .element("name", "Jenkins")
+                .element("ui.external", true);
+
+        JSONObject params = new JSONObject();
+        params.element("buildTargetPHID", phid)
+                .element("artifactKey", "jenkins.uri")
+                .element("artifactType", "uri")
+                .element("artifactData", artifactData);
+
         return this.callConduit("harbormaster.createartifact", params);
     }
 
@@ -137,10 +135,6 @@ public class DifferentialClient {
      */
     public JSONObject postComment(String revisionID, String message) throws ConduitAPIException, IOException {
         return postComment(revisionID, message, true, "none");
-    }
-
-    protected JSONObject callConduit(String methodName, Map<String, String> params) throws ConduitAPIException, IOException {
-        return conduit.perform(methodName, params);
     }
 
     protected JSONObject callConduit(String methodName, JSONObject params) throws ConduitAPIException, IOException {

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/DifferentialClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/DifferentialClient.java
@@ -50,9 +50,9 @@ public class DifferentialClient {
     public JSONObject postComment(String revisionID, String message, boolean silent, String action) throws IOException, ConduitAPIException {
         JSONObject params = new JSONObject();
         params.element("revision_id", revisionID)
-            .element("action", action)
-            .element("message", message)
-            .element("silent", silent);
+                .element("action", action)
+                .element("message", message)
+                .element("silent", silent);
 
         return this.callConduit("differential.createcomment", params);
     }

--- a/src/test/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClientTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClientTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 public class ConduitAPIClientTest {
     private LocalTestServer server;
     private ConduitAPIClient client;
-    private final Map<String, String> emptyParams = new HashMap<String, String>();
+    private final JSONObject emptyParams = new JSONObject();
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClientTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClientTest.java
@@ -29,8 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -76,7 +74,7 @@ public class ConduitAPIClientTest {
     @Test
     public void testWithParams() throws UnsupportedEncodingException, ConduitAPIException {
         client = new ConduitAPIClient("http://foo.bar", TestUtils.TEST_CONDUIT_TOKEN);
-        Map<String, String> params = new HashMap<String, String>();
+        JSONObject params = new JSONObject().element("hello", "world");
         params.put("hello", "world");
         client.createRequest("action", params);
     }

--- a/src/test/java/com/uber/jenkins/phabricator/conduit/DifferentialClientTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/conduit/DifferentialClientTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
@@ -117,7 +117,7 @@ public class DifferentialClientTest {
     private void mockConduitResponse(DifferentialClient client, JSONObject response) throws IOException, ConduitAPIException {
         doReturn(response).when(client).callConduit(
                 anyString(),
-                anyMap()
+                any(JSONObject.class)
         );
     }
 }


### PR DESCRIPTION
Instead of having two APIs, where we were confusingly using a Map<String,
String> even when it contained complex objects, use a real JSONObject everywhere.

/r @cburroughs