### PR TITLE
Add integration tests for build wrapper and notifier

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/ConduitCredentialsDescriptor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/ConduitCredentialsDescriptor.java
@@ -20,6 +20,7 @@
 
 package com.uber.jenkins.phabricator;
 
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
@@ -51,9 +52,15 @@ public class ConduitCredentialsDescriptor {
         if (available.size() == 0) {
             return null;
         }
+        CredentialsMatcher matcher;
+        if (credentialsID != null) {
+            matcher = CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsID));
+        } else {
+            matcher = CredentialsMatchers.always();
+        }
         return CredentialsMatchers.firstOrDefault(
                 available,
-                CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsID)),
+                matcher,
                 available.get(0)
         );
     }

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -131,11 +131,6 @@ public class PhabricatorNotifier extends Notifier {
             diff.decorate(build, this.getPhabricatorURL(build.getParent()));
         }
 
-        String revisionID = diff.getRevisionID(true);
-        if (CommonUtils.isBlank(revisionID)) {
-            return this.ignoreBuild(logger.getStream(), "Unable to load revisionID from conduit for diff ID " + diffID);
-        }
-
         String phid = environment.get(PhabricatorPlugin.PHID_FIELD);
 
         boolean runHarbormaster = !CommonUtils.isBlank(phid);
@@ -251,12 +246,6 @@ public class PhabricatorNotifier extends Notifier {
             logger.info(UBERALLS_TAG, "No cobertura results found");
             return null;
         }
-    }
-
-    private boolean ignoreBuild(PrintStream logger, String message) {
-        logger.println(message);
-        logger.println("Skipping Phabricator notification.");
-        return true;
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorPlugin.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorPlugin.java
@@ -28,9 +28,9 @@ import java.io.File;
 
 public class PhabricatorPlugin extends Plugin {
     // Diff ID (not differential ID)
-    static final String DIFFERENTIAL_ID_FIELD = "DIFF_ID";
+    public static final String DIFFERENTIAL_ID_FIELD = "DIFF_ID";
     // Phabricator object ID (for Harbormaster)
-    static final String PHID_FIELD = "PHID";
+    public static final String PHID_FIELD = "PHID";
 
     public static String getIconPath(String icon) {
         if (icon == null) {

--- a/src/test/java/com/uber/jenkins/phabricator/BuildIntegrationTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/BuildIntegrationTest.java
@@ -20,20 +20,35 @@
 
 package com.uber.jenkins.phabricator;
 
+import com.uber.jenkins.phabricator.utils.TestUtils;
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
+import net.sf.json.JSONObject;
+import org.junit.After;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
 
-public class BuildIntegrationTest {
+public abstract class BuildIntegrationTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
+    protected FakeConduit conduit;
+
     FreeStyleProject p;
+
+    @After
+    public void tearDown() throws Exception {
+        if (conduit != null) {
+            conduit.stop();
+        }
+    }
 
     void assertSuccessfulBuild(Result result) {
         assertTrue(result.isCompleteBuild());
@@ -42,5 +57,25 @@ public class BuildIntegrationTest {
 
     FreeStyleProject createProject() throws IOException {
         return j.createFreeStyleProject();
+    }
+
+    protected abstract void addBuildStep();
+
+    protected FreeStyleBuild buildWithConduit(JSONObject queryDiffsResponse, JSONObject postCommentResponse) throws Exception {
+        Map<String, JSONObject> responses = new HashMap<String, JSONObject>();
+        if (queryDiffsResponse != null) {
+            responses.put("differential.querydiffs", queryDiffsResponse);
+        }
+        if (postCommentResponse != null) {
+            responses.put("differential.createcomment", postCommentResponse);
+        }
+        conduit = new FakeConduit(responses);
+
+        TestUtils.addValidCredentials(conduit);
+
+        addBuildStep();
+        TestUtils.setDefaultBuildEnvironment(j);
+
+        return p.scheduleBuild2(0).get();
     }
 }

--- a/src/test/java/com/uber/jenkins/phabricator/BuildIntegrationTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/BuildIntegrationTest.java
@@ -20,6 +20,7 @@
 
 package com.uber.jenkins.phabricator;
 
+import com.uber.jenkins.phabricator.conduit.ConduitAPIClientTest;
 import com.uber.jenkins.phabricator.utils.TestUtils;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -61,7 +62,11 @@ public abstract class BuildIntegrationTest {
 
     protected abstract void addBuildStep();
 
-    protected FreeStyleBuild buildWithConduit(JSONObject queryDiffsResponse, JSONObject postCommentResponse) throws Exception {
+    protected JSONObject getFetchDiffResponse() throws IOException {
+        return TestUtils.getJSONFromFile(ConduitAPIClientTest.class, "validFetchDiffResponse");
+    }
+
+    protected FreeStyleBuild buildWithConduit(JSONObject queryDiffsResponse, JSONObject postCommentResponse, JSONObject sendMessageResponse) throws Exception {
         Map<String, JSONObject> responses = new HashMap<String, JSONObject>();
         if (queryDiffsResponse != null) {
             responses.put("differential.querydiffs", queryDiffsResponse);
@@ -69,11 +74,15 @@ public abstract class BuildIntegrationTest {
         if (postCommentResponse != null) {
             responses.put("differential.createcomment", postCommentResponse);
         }
+        if (sendMessageResponse != null) {
+            responses.put("harbormaster.sendmessage", sendMessageResponse);
+        }
         conduit = new FakeConduit(responses);
 
         TestUtils.addValidCredentials(conduit);
 
         addBuildStep();
+
         TestUtils.setDefaultBuildEnvironment(j);
 
         return p.scheduleBuild2(0).get();

--- a/src/test/java/com/uber/jenkins/phabricator/FakeConduit.java
+++ b/src/test/java/com/uber/jenkins/phabricator/FakeConduit.java
@@ -42,7 +42,7 @@ public class FakeConduit {
         server.stop();
     }
 
-    public String URI() {
+    public String uri() {
         return TestUtils.getTestServerAddress(server);
     }
 

--- a/src/test/java/com/uber/jenkins/phabricator/FakeConduit.java
+++ b/src/test/java/com/uber/jenkins/phabricator/FakeConduit.java
@@ -1,0 +1,55 @@
+// Copyright (c) 2015 Uber
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package com.uber.jenkins.phabricator;
+
+import com.uber.jenkins.phabricator.utils.TestUtils;
+import net.sf.json.JSONObject;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.localserver.LocalTestServer;
+
+import java.util.Map;
+
+public class FakeConduit {
+    private LocalTestServer server;
+
+    public FakeConduit(Map<String, JSONObject> responses) throws Exception {
+        server = new LocalTestServer(null, null);
+        for (Map.Entry<String, JSONObject> entry : responses.entrySet()) {
+            register(entry.getKey(), entry.getValue());
+        }
+        server.start();
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+    }
+
+    public String URI() {
+        return TestUtils.getTestServerAddress(server);
+    }
+
+    public void register(String method, JSONObject response) {
+        server.register(
+                "/api/" + method,
+                TestUtils.makeHttpHandler(HttpStatus.SC_OK, response.toString(2))
+        );
+    }
+}

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
@@ -20,15 +20,12 @@
 
 package com.uber.jenkins.phabricator;
 
-import com.uber.jenkins.phabricator.conduit.ConduitAPIClientTest;
 import com.uber.jenkins.phabricator.utils.TestUtils;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
 import net.sf.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
 
 import static org.junit.Assert.*;
 
@@ -94,20 +91,20 @@ public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
 
     @Test
     public void testBuildValidConduitEmptyResponse() throws Exception {
-        FreeStyleBuild build = buildWithConduit(null, null);
+        FreeStyleBuild build = buildWithConduit(null, null, null);
         assertEquals(Result.FAILURE, build.getResult());
     }
 
     @Test
     public void testBuildValidErrorCommenting() throws Exception {
-        FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), null);
+        FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), null, null);
         assertEquals(Result.FAILURE, build.getResult());
     }
 
     @Test
     public void testBuildValidSuccess() throws Exception {
         JSONObject commentResponse = new JSONObject();
-        FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), commentResponse);
+        FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), commentResponse, null);
 
         assertEquals(Result.SUCCESS, build.getResult());
         PhabricatorPostbuildSummaryAction action = build.getAction(PhabricatorPostbuildSummaryAction.class);
@@ -121,15 +118,10 @@ public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
     public void testBuildWithErrorOnArcanist() throws Exception {
         wrapper.getDescriptor().setArcPath("false");
         JSONObject commentResponse = new JSONObject();
-        FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), commentResponse);
+        FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), commentResponse, null);
 
         assertEquals(Result.FAILURE, build.getResult());
     }
-
-    private JSONObject getFetchDiffResponse() throws IOException {
-        return TestUtils.getJSONFromFile(ConduitAPIClientTest.class, "validFetchDiffResponse");
-    }
-
 
     @Override
     protected void addBuildStep() {

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -20,12 +20,16 @@
 
 package com.uber.jenkins.phabricator;
 
+import com.uber.jenkins.phabricator.utils.TestUtils;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
+import net.sf.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static org.junit.Assert.*;
 
 public class PhabricatorNotifierTest extends BuildIntegrationTest {
     private PhabricatorNotifier notifier;
@@ -43,13 +47,11 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
     }
 
     @Test
-    public void testNoParametersBuild() throws Exception {
-        p.getPublishersList().add(notifier);
-
-        FreeStyleBuild build = p.scheduleBuild2(0).get();
-        Result result = build.getResult();
-
-        assertSuccessfulBuild(result);
+    public void testGetters() {
+        assertFalse(notifier.isCommentOnSuccess());
+        assertTrue(notifier.isUberallsEnabled());
+        assertEquals(".phabricator-comment", notifier.getCommentFile());
+        assertFalse(notifier.isCommentWithConsoleLinkOnFailure());
     }
 
     @Test
@@ -60,6 +62,44 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
         PhabricatorNotifier after = p.getPublishersList().get(PhabricatorNotifier.class);
         j.assertEqualBeans(notifier, after,
                 "commentOnSuccess,uberallsEnabled,commentWithConsoleLinkOnFailure,commentFile");
+    }
+
+    @Test
+    public void testNoParametersBuild() throws Exception {
+        addBuildStep();
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        Result result = build.getResult();
+
+        assertSuccessfulBuild(result);
+    }
+
+    @Test
+    public void testNoCredentials() throws Exception {
+        addBuildStep();
+        TestUtils.setDefaultBuildEnvironment(j);
+
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        assertEquals(Result.FAILURE, build.getResult());
+    }
+
+    @Test
+    public void testWithCredentialsIgnoresMissingConduit() throws Exception {
+        FreeStyleBuild build = buildWithConduit(null, null, null);
+        assertEquals(Result.SUCCESS, build.getResult());
+    }
+
+    @Test
+    public void testUnableToPostToHarbormaster() throws Exception {
+        FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), null, null);
+
+        assertEquals(Result.FAILURE, build.getResult());
+    }
+
+    @Test
+    public void testPostToHarbormaster() throws Exception {
+        FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), null, new JSONObject());
+
+        assertEquals(Result.SUCCESS, build.getResult());
     }
 
     @Override

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -54,12 +54,16 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
 
     @Test
     public void testRoundTripConfiguration() throws Exception {
-        p.getPublishersList().add(notifier);
-
+        addBuildStep();
         j.submit(j.createWebClient().getPage(p, "configure").getFormByName("config"));
 
         PhabricatorNotifier after = p.getPublishersList().get(PhabricatorNotifier.class);
         j.assertEqualBeans(notifier, after,
                 "commentOnSuccess,uberallsEnabled,commentWithConsoleLinkOnFailure,commentFile");
+    }
+
+    @Override
+    protected void addBuildStep() {
+        p.getPublishersList().add(notifier);
     }
 }

--- a/src/test/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClientTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/conduit/ConduitAPIClientTest.java
@@ -80,10 +80,6 @@ public class ConduitAPIClientTest {
     }
 
     private String getTestServerAddress() {
-        return String.format(
-                "http://%s:%s",
-                server.getServiceAddress().getHostName(),
-                server.getServiceAddress().getPort()
-        );
+        return TestUtils.getTestServerAddress(server);
     }
 }

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -20,19 +20,28 @@
 
 package com.uber.jenkins.phabricator.utils;
 
-import com.uber.jenkins.phabricator.coverage.CodeCoverageMetrics;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.uber.jenkins.phabricator.FakeConduit;
 import com.uber.jenkins.phabricator.LauncherFactory;
+import com.uber.jenkins.phabricator.PhabricatorPlugin;
 import com.uber.jenkins.phabricator.conduit.ConduitAPIClient;
 import com.uber.jenkins.phabricator.conduit.DifferentialClient;
+import com.uber.jenkins.phabricator.coverage.CodeCoverageMetrics;
+import com.uber.jenkins.phabricator.credentials.ConduitCredentials;
+import com.uber.jenkins.phabricator.credentials.ConduitCredentialsImpl;
 import com.uber.jenkins.phabricator.uberalls.UberallsClient;
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 import net.sf.json.JSONObject;
 import net.sf.json.groovy.JsonSlurper;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.localserver.LocalTestServer;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpRequestHandler;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -41,6 +50,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -55,6 +66,8 @@ public class TestUtils {
     public static final String TEST_DIFFERENTIAL_ID = "123";
     public static final String TEST_CONDUIT_TOKEN = "notarealtoken";
     public static final String TEST_PHID = "PHID-not-real";
+    private static final String TEST_CREDENTIALS_ID = "not-a-real-uuid-for-credentials";
+    private static final String TEST_CONDUIT_URL = "http://example.gophers";
 
     public static Logger getDefaultLogger() {
         return new Logger(new PrintStream(new ByteArrayOutputStream()));
@@ -137,5 +150,52 @@ public class TestUtils {
 
             }
         };
+    }
+
+    public static void setEnvironmentVariables(JenkinsRule j, Map<String, String> params) throws IOException {
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars envVars = prop.getEnvVars();
+        envVars.putAll(params);
+        j.jenkins.getGlobalNodeProperties().add(prop);
+    }
+
+    public static Map<String, String> getValidBuildEnvironment() {
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(PhabricatorPlugin.DIFFERENTIAL_ID_FIELD, TEST_DIFFERENTIAL_ID);
+        params.put(PhabricatorPlugin.PHID_FIELD, TEST_PHID);
+        return params;
+    }
+
+    public static void setDefaultBuildEnvironment(JenkinsRule j) throws IOException {
+        setEnvironmentVariables(j, getValidBuildEnvironment());
+    }
+
+    public static ConduitCredentials getConduitCredentials(String conduitURI) {
+        return new ConduitCredentialsImpl(TEST_CREDENTIALS_ID, conduitURI, "description", TestUtils.TEST_CONDUIT_TOKEN);
+    }
+
+    public static ConduitCredentials getDefaultConduitCredentials() {
+        return getConduitCredentials(TEST_CONDUIT_URL);
+    }
+
+    private static void addCredentials(ConduitCredentials credentials) throws IOException {
+        CredentialsStore store = new SystemCredentialsProvider.UserFacingAction().getStore();
+        store.addCredentials(Domain.global(), credentials);
+    }
+
+    public static void addInvalidCredentials() throws IOException {
+        addCredentials(TestUtils.getDefaultConduitCredentials());
+    }
+
+    public static void addValidCredentials(FakeConduit conduit) throws IOException {
+        addCredentials(TestUtils.getConduitCredentials(conduit.URI()));
+    }
+
+    public static String getTestServerAddress(LocalTestServer server) {
+        return String.format(
+                "http://%s:%s",
+                server.getServiceAddress().getHostName(),
+                server.getServiceAddress().getPort()
+        );
     }
 }

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -188,7 +188,7 @@ public class TestUtils {
     }
 
     public static void addValidCredentials(FakeConduit conduit) throws IOException {
-        addCredentials(TestUtils.getConduitCredentials(conduit.URI()));
+        addCredentials(TestUtils.getConduitCredentials(conduit.uri()));
     }
 
     public static String getTestServerAddress(LocalTestServer server) {

--- a/src/test/resources/com/uber/jenkins/phabricator/conduit/validFetchDiffResponse.json
+++ b/src/test/resources/com/uber/jenkins/phabricator/conduit/validFetchDiffResponse.json
@@ -1,6 +1,7 @@
 {
   "result": {
     "123": {
+      "revisionID": "42",
       "sourceControlBaseRevision": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
       "hello": "world",
       "authorName": "aiden",

--- a/src/test/resources/com/uber/jenkins/phabricator/conduit/validFetchDiffResponse.json
+++ b/src/test/resources/com/uber/jenkins/phabricator/conduit/validFetchDiffResponse.json
@@ -1,7 +1,10 @@
 {
   "result": {
     "123": {
-      "hello": "world"
+      "sourceControlBaseRevision": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+      "hello": "world",
+      "authorName": "aiden",
+      "authorEmail": "sc@ndella.com"
     }
   }
 }


### PR DESCRIPTION
This tests the end-to-end flow of both the wrapper and the notifier, against a "real" Phabricator backend (in-process HTTP server mimicking the Conduit API).