### PR TITLE
Remove deprecated conduit fields

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -170,7 +170,7 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
         if (credentials != null) {
             return credentials.getUrl();
         }
-        return getDescriptor().getConduitURL();
+        return null;
     }
 
     private String getConduitToken(Job owner, Logger logger) {
@@ -178,8 +178,8 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
         if (credentials != null) {
             return credentials.getToken().getPlainText();
         }
-        logger.warn("credentials", "No credentials configured. Falling back to deprecated configuration.");
-        return getDescriptor().getConduitToken();
+        logger.warn("credentials", "No credentials configured.");
+        return null;
     }
 
     /**

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperDescriptor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperDescriptor.java
@@ -36,8 +36,6 @@ import org.kohsuke.stapler.StaplerRequest;
 @Extension
 public final class PhabricatorBuildWrapperDescriptor extends BuildWrapperDescriptor {
     private String credentialsID;
-    private String conduitURL;
-    private String conduitToken;
     private String arcPath;
 
     public PhabricatorBuildWrapperDescriptor() {
@@ -83,22 +81,6 @@ public final class PhabricatorBuildWrapperDescriptor extends BuildWrapperDescrip
 
     public void setCredentialsID(String credentialsID) {
         this.credentialsID = credentialsID;
-    }
-
-    public String getConduitURL() {
-        return conduitURL;
-    }
-
-    public void setConduitURL(String value) {
-        conduitURL = value;
-    }
-
-    public String getConduitToken() {
-        return conduitToken;
-    }
-
-    public void setConduitToken(String conduitToken) {
-        this.conduitToken = conduitToken;
     }
 
     public String getArcPath() {

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/global.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/global.jelly
@@ -22,15 +22,6 @@
         <c:select />
       </f:entry>
 
-      <f:entry title="Phabricator URL (deprecated)" field="conduitURL"
-               description="Use credentials instead. Location of the Phabricator instance">
-        <f:textbox />
-      </f:entry>
-      <f:entry title="Conduit Token (deprecated)" field="conduitToken"
-               description="Use credentials instead. Conduit token for Phabricator API. If left blank, reads from ~/.arcrc">
-        <f:textbox />
-      </f:entry>
-
       <f:entry title="Location of arcanist" field="arcPath"
                description="location of `arc` binary, if not in path">
         <f:textbox default="arc" />


### PR DESCRIPTION
These were moved to the Credentials plugin in the 1.7 series of the
plugin, and are now past deprecation.