### PR TITLE
Post coverage even when Uberalls is disabled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.8.1 (unreleased)
+
+* Don't require Uberalls to be enabled to post coverage data to Harbormaster
+
 ### 1.8.0 (2015/09/09)
 
 * Qualify log statements with "phabricator:"

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -84,7 +84,7 @@ public class PhabricatorNotifier extends Notifier {
         EnvVars environment = build.getEnvironment(listener);
         Logger logger = new Logger(listener.getLogger());
 
-        final CoverageProvider coverageProvider = getUberallsCoverage(build, listener);
+        final CoverageProvider coverageProvider = getCoverageProvider(build, listener);
         CodeCoverageMetrics coverageResult = null;
         if (coverageProvider != null) {
             coverageResult = coverageProvider.getMetrics();
@@ -153,7 +153,9 @@ public class PhabricatorNotifier extends Notifier {
                 preserveFormatting
         );
 
-        resultProcessor.processParentCoverage(uberallsClient);
+        if (uberallsEnabled) {
+            resultProcessor.processParentCoverage(uberallsClient);
+        }
 
         // Add in comments about the build result
         resultProcessor.processBuildResult(commentOnSuccess, commentWithConsoleLinkOnFailure);
@@ -190,8 +192,8 @@ public class PhabricatorNotifier extends Notifier {
      * @param listener The build listener
      * @return The current cobertura coverage, if any
      */
-    private CoverageProvider getUberallsCoverage(AbstractBuild build, BuildListener listener) {
-        if (!build.getResult().isBetterOrEqualTo(Result.UNSTABLE) || !uberallsEnabled) {
+    private CoverageProvider getCoverageProvider(AbstractBuild build, BuildListener listener) {
+        if (!build.getResult().isBetterOrEqualTo(Result.UNSTABLE)) {
             return null;
         }
 

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -128,6 +128,19 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
     }
 
     @Test
+    public void testPostCoverageUberallsDisabled() throws Exception {
+        notifier = new PhabricatorNotifier(
+                false,
+                false,
+                true,
+                ".phabricator-comment",
+                "1000",
+                false
+        );
+        testPostCoverage();
+    }
+
+    @Test
     public void testDescriptor() {
         PhabricatorNotifierDescriptor descriptor = notifier.getDescriptor();
 


### PR DESCRIPTION
This option shouldn't be required just to make inline (differential)
coverage data available.

Fixes #98

/r @jjx @audriusm 