### PR TITLE
Fix "comment size" option not being respected

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.8.2 (unreleased)
+
+* Fix "comment size" option not being saved
+
 ### 1.8.1 (2015/09/22)
 
 * Don't require Uberalls to be enabled to post coverage data to Harbormaster

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -258,6 +258,11 @@ public class PhabricatorNotifier extends Notifier {
     }
 
     @SuppressWarnings("UnusedDeclaration")
+    public String getCommentSize() {
+        return commentSize;
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
     public boolean isPreserveFormatting() {
         return preserveFormatting;
     }

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -44,7 +44,7 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
                 true,
                 true,
                 ".phabricator-comment",
-                "1000",
+                "1001",
                 false
         );
     }
@@ -55,6 +55,7 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
         assertTrue(notifier.isUberallsEnabled());
         assertTrue(notifier.isPreserveFormatting());
         assertEquals(".phabricator-comment", notifier.getCommentFile());
+        assertEquals("1001", notifier.getCommentSize());
         assertFalse(notifier.isCommentWithConsoleLinkOnFailure());
     }
 
@@ -65,7 +66,7 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
 
         PhabricatorNotifier after = p.getPublishersList().get(PhabricatorNotifier.class);
         j.assertEqualBeans(notifier, after,
-                "commentOnSuccess,uberallsEnabled,commentWithConsoleLinkOnFailure,commentFile");
+                "commentOnSuccess,uberallsEnabled,commentWithConsoleLinkOnFailure,commentFile,commentSize");
     }
 
     @Test


### PR DESCRIPTION
The getter was never defined, so the UI was always resetting to the default
value.

/r @audriusm 