### PR TITLE
Allow user to apply patch with force flag

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -49,16 +49,18 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
     private final boolean showBuildStartedMessage;
     private final boolean skipForcedClean;
     private final boolean createBranch;
+    private final boolean patchWithForceFlag;
 
     @DataBoundConstructor
     public PhabricatorBuildWrapper(boolean createCommit, boolean applyToMaster,
                                    boolean showBuildStartedMessage, boolean skipForcedClean,
-                                   boolean createBranch) {
+                                   boolean createBranch, boolean patchWithForceFlag) {
         this.createCommit = createCommit;
         this.applyToMaster = applyToMaster;
         this.showBuildStartedMessage = showBuildStartedMessage;
         this.skipForcedClean = skipForcedClean;
         this.createBranch = createBranch;
+        this.patchWithForceFlag = patchWithForceFlag;
     }
 
     /** {@inheritDoc} */
@@ -118,7 +120,8 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
         final String conduitToken = this.getConduitToken(build.getParent(), logger);
         Task.Result result = new ApplyPatchTask(
                 logger, starter, baseCommit, diffID, conduitToken, getArcPath(),
-                DEFAULT_GIT_PATH, createCommit, skipForcedClean, createBranch
+                DEFAULT_GIT_PATH, createCommit, skipForcedClean, createBranch,
+                patchWithForceFlag
         ).run();
 
         if (result != Task.Result.SUCCESS) {
@@ -174,6 +177,11 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
     @SuppressWarnings("UnusedDeclaration")
     public boolean isCreateBranch() {
         return createBranch;
+    }
+
+    @SuppressWarnings("unused")
+    public boolean isPatchWithForceFlag() {
+        return patchWithForceFlag;
     }
 
     private String getPhabricatorURL(Job owner) {

--- a/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
+++ b/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
@@ -41,11 +41,12 @@ public class ApplyPatchTask extends Task {
     private final String gitPath;
     private final boolean skipForcedClean;
     private final boolean createBranch;
+    private final boolean patchWithForceFlag;
 
     public ApplyPatchTask(Logger logger, LauncherFactory starter, String baseCommit,
                           String diffID, String conduitToken, String arcPath,
                           String gitPath, boolean createCommit, boolean skipForcedClean,
-                          boolean createBranch) {
+                          boolean createBranch, boolean patchWithForceFlag) {
         super(logger);
         this.starter = starter;
         this.baseCommit = baseCommit;
@@ -56,6 +57,7 @@ public class ApplyPatchTask extends Task {
         this.createCommit = createCommit;
         this.skipForcedClean = skipForcedClean;
         this.createBranch = createBranch;
+        this.patchWithForceFlag = patchWithForceFlag;
 
         this.logStream = logger.getStream();
     }
@@ -112,6 +114,10 @@ public class ApplyPatchTask extends Task {
 
             if (!createBranch) {
                 arcPatchParams.add("--nobranch");
+            }
+
+            if (patchWithForceFlag) {
+                arcPatchParams.add("--force");
             }
 
             ArcanistClient arc = new ArcanistClient(

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/config.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/config.jelly
@@ -20,4 +20,8 @@
            description="Create a git branch with the patch">
       <f:checkbox />
   </f:entry>
+  <f:entry title="Run 'arc patch' with '--force'" field="patchWithForceFlag"
+           description="Skips running sanity checks (like base commit) when applying patch">
+      <f:checkbox default="false" />
+  </f:entry>
 </j:jelly>

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
@@ -40,6 +40,7 @@ public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
                 false,
                 true,
                 false,
+                false,
                 false
         );
         wrapper.getDescriptor().setArcPath("echo");
@@ -50,6 +51,7 @@ public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
         assertFalse(wrapper.isCreateCommit());
         assertFalse(wrapper.isApplyToMaster());
         assertTrue(wrapper.isShowBuildStartedMessage());
+        assertFalse(wrapper.isPatchWithForceFlag());
     }
 
     @Test

--- a/src/test/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTaskTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTaskTest.java
@@ -62,7 +62,8 @@ public class ApplyPatchTaskTest {
                 gitPath, // git path
                 false, // createCommit
                 false, // skipForcedClean
-                false // createBranch
+                false, // createBranch
+                false  // patchWithForceFlag
         );
     }
 }


### PR DESCRIPTION
This runs `arc patch` with `--force` flag. This lets diffs which depend on a base-commit
not found in the repo applied on top of the current HEAD.

Closes #104, #115