### PR TITLE
Fix plugin dependency checking

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * Add more logging on differential fetch failure
 * Allow user to apply patch with force flag (Chaitanya Pramod)
+* Fix crash when missing cobertura plugin
 
 ### 1.8.3 (2015/12/09)
 

--- a/src/main/java/com/uber/jenkins/phabricator/provider/InstanceProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/provider/InstanceProvider.java
@@ -55,6 +55,7 @@ public class InstanceProvider<T> {
     public T getInstance() {
         if (!provider.isAvailable()) {
             logger.info(LOGGER_TAG, String.format("'%s' plugin not installed.", pluginName));
+            return null;
         }
         T instance = provider.getInstance(className);
         if (instance == null) {

--- a/src/test/java/com/uber/jenkins/phabricator/provider/InstanceProviderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/provider/InstanceProviderTest.java
@@ -39,6 +39,12 @@ public class InstanceProviderTest {
     }
 
     @Test
+    public void testUnavailablePluginValidClass() {
+        InstanceProvider<UnitTestProvider> provider = makeProvider("weird-plugin-name", "com.uber.jenkins.phabricator.unit.JUnitTestProvider");
+        assertNull(provider.getInstance());
+    }
+
+    @Test
     public void testBadClassName() {
         InstanceProvider<UnitTestProvider> provider = makeProvider("junit", "com.nonexistent.class");
         assertNull(provider.getInstance());


### PR DESCRIPTION
We were attempting to load the class even if the plugin was not
installed, leading to crashes.

Fixes #117