### PR TITLE
Skip configuration test in suite

### DIFF
--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
@@ -25,6 +25,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
 import net.sf.json.JSONObject;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -54,6 +55,7 @@ public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
         assertFalse(wrapper.isPatchWithForceFlag());
     }
 
+    @Ignore("causes travis CI to crash")
     @Test
     public void testRoundTripConfiguration() throws Exception {
         addBuildStep();


### PR DESCRIPTION
This causes Travis-CI to crash about half the time, leading to annoyingly flaky build statuses.

Fixes #124 