### PR TITLE
Break out of containers for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: java
+sudo: true
 
 matrix:
   fast_finish: true

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
@@ -25,7 +25,6 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
 import net.sf.json.JSONObject;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -55,7 +54,6 @@ public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
         assertFalse(wrapper.isPatchWithForceFlag());
     }
 
-    @Ignore("causes travis CI to crash")
     @Test
     public void testRoundTripConfiguration() throws Exception {
         addBuildStep();


### PR DESCRIPTION
Maybe this will make the builds more reliable?

See more: https://github.com/travis-ci/travis-ci/issues/5597