### PR TITLE
Note that BUILD_URL may already be set

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
@@ -148,7 +148,8 @@ public class BuildResultProcessor {
             Task.Result sendUriResult = new SendHarbormasterUriTask(logger, diffClient, phid, buildUrl).run();
 
             if (sendUriResult != Task.Result.SUCCESS) {
-                logger.info(LOGGING_TAG, "Unable to send BUILD_URL to Harbormaster");
+                logger.info(LOGGING_TAG, "Unable to send BUILD_URL to Harbormaster. " +
+			    "This can be safely ignored, and is usually because it's already set.");
             }
 
             if (unitResults != null) {


### PR DESCRIPTION
Because of the PR we just merged, this is now getting set in the
BuildWrapper phase (e.g. when we apply the differential). Many people
use both the BuildWrapper and the Notifier (to publish results), in
which case this will be a harmless error.