### PR TITLE
Don't make PHID required for BuildWrapper

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -85,9 +85,9 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
 
         String phid = environment.get(PhabricatorPlugin.PHID_FIELD);
         String diffID = environment.get(PhabricatorPlugin.DIFFERENTIAL_ID_FIELD);
-        if (CommonUtils.isBlank(diffID) || CommonUtils.isBlank(phid)) {
+        if (CommonUtils.isBlank(diffID)) {
             this.addShortText(build);
-            this.ignoreBuild(logger, "No differential ID or PHID found.");
+            this.ignoreBuild(logger, "No differential ID found.");
             return new Environment(){};
         }
 
@@ -104,12 +104,14 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
 
         DifferentialClient diffClient = new DifferentialClient(diffID, conduitClient);
 
-        logger.info("harbormaster", "Sending Harbormaster BUILD_URL via PHID: " + phid);
-        String buildUrl = environment.get("BUILD_URL");
-        Task.Result sendUriResult = new SendHarbormasterUriTask(logger, diffClient, phid, buildUrl).run();
+        if (!CommonUtils.isBlank(phid)) {
+            logger.info("harbormaster", "Sending Harbormaster BUILD_URL via PHID: " + phid);
+            String buildUrl = environment.get("BUILD_URL");
+            Task.Result sendUriResult = new SendHarbormasterUriTask(logger, diffClient, phid, buildUrl).run();
 
-        if (sendUriResult != Task.Result.SUCCESS) {
-            logger.info("harbormaster", "Unable to send BUILD_URL to Harbormaster");
+            if (sendUriResult != Task.Result.SUCCESS) {
+                logger.info("harbormaster", "Unable to send BUILD_URL to Harbormaster");
+            }
         }
 
         Differential diff;

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/Differential.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/Differential.java
@@ -107,7 +107,7 @@ public class Differential {
     @SuppressWarnings("StringBufferReplaceableByString")
     public String getBuildStartedMessage(EnvVars environment) {
         StringBuilder sb = new StringBuilder("[DEPRECATED: Build started message is deprecated, " +
-                "consider upgrading Phabricator to get Build URL as Harbormaster artifact]");
+                "consider upgrading Phabricator to get Build URL as Harbormaster artifact] ");
         sb.append("Build started: %s (console: %sconsole)");
         return String.format(sb.toString(), environment.get("BUILD_URL"), environment.get("BUILD_URL"));
     }


### PR DESCRIPTION
At Uber, we still have some legacy projects that aren't setting a
PHID. We want to keep supporting applying differentials for those, at
least until we can migrate them.