### PR TITLE
Publish inline coverage data only for changed files in the diff

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 1.9.4 (unreleased)
+
+* Publish inline coverage data only for changed files in the diff
+* Cleanup coverage files on jenkins master to save disk space
+
 ### 1.9.3 (2016/04/1)
 
 * Remove deprecated "Build started" comments in favor of Harbormaster

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -189,7 +189,7 @@ public class PhabricatorNotifier extends Notifier {
         resultProcessor.processUnitResults(getUnitProvider(build, listener));
 
         // Read coverage data to send to Harbormaster
-        resultProcessor.processCoverage(coverageProvider);
+        resultProcessor.processCoverage(coverageProvider, diff.getChangedFiles());
 
         // Fail the build if we can't report to Harbormaster
         if (!resultProcessor.processHarbormaster()) {

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/DifferentialClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/DifferentialClient.java
@@ -25,8 +25,6 @@ import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 /**

--- a/src/test/java/com/uber/jenkins/phabricator/BuildResultProcessorTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/BuildResultProcessorTest.java
@@ -20,6 +20,7 @@
 
 package com.uber.jenkins.phabricator;
 
+import com.google.common.collect.Sets;
 import com.uber.jenkins.phabricator.conduit.Differential;
 import com.uber.jenkins.phabricator.conduit.DifferentialClient;
 import com.uber.jenkins.phabricator.coverage.CodeCoverageMetrics;
@@ -29,6 +30,8 @@ import com.uber.jenkins.phabricator.utils.TestUtils;
 import hudson.model.AbstractBuild;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -55,22 +58,30 @@ public class BuildResultProcessorTest {
     @Test
     public void testProcessCoverage() throws Exception {
         CoverageProvider provider = new FakeCoverageProvider(TestUtils.getDefaultLineCoverage());
-        processor.processCoverage(provider);
+        processor.processCoverage(provider, Sets.newHashSet("file.go"));
         assertNotNull(processor.getCoverage());
         assertNotNull(processor.getCoverage().get("file.go"));
         assertEquals("NCUC", processor.getCoverage().get("file.go"));
     }
 
     @Test
+    public void testProcessCoverageWithNoIncludes() throws Exception {
+        CoverageProvider provider = new FakeCoverageProvider(TestUtils.getDefaultLineCoverage());
+        processor.processCoverage(provider, Sets.newHashSet("file2.go"));
+        assertNotNull(processor.getCoverage());
+        assertNull(processor.getCoverage().get("file.go"));
+    }
+
+    @Test
     public void testProcessEmptyCoverage() {
         CoverageProvider provider = new FakeCoverageProvider(null);
-        processor.processCoverage(provider);
+        processor.processCoverage(provider, Sets.<String>newHashSet());
         assertNull(processor.getCoverage());
     }
 
     @Test
     public void testProcessNullProvider() {
-        processor.processCoverage(null);
+        processor.processCoverage(null, Sets.<String>newHashSet());
         assertNull(processor.getCoverage());
     }
 

--- a/src/test/java/com/uber/jenkins/phabricator/conduit/DifferentialTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/conduit/DifferentialTest.java
@@ -20,6 +20,7 @@
 
 package com.uber.jenkins.phabricator.conduit;
 
+import com.google.common.collect.Sets;
 import com.uber.jenkins.phabricator.PhabricatorPostbuildSummaryAction;
 import com.uber.jenkins.phabricator.utils.TestUtils;
 import hudson.EnvVars;
@@ -99,5 +100,13 @@ public class DifferentialTest extends TestCase {
 
         assertEquals("unknown", summary.getAuthorName());
         assertEquals("unknown", summary.getAuthorEmail());
+    }
+
+    @Test
+    public void testFetchDiffResponseWithChanges() throws Exception {
+        JSONObject response = TestUtils.getJSONFromFile(getClass(), "ResponseWithChanges");
+        differential = new Differential(response);
+
+        assertEquals(Sets.newHashSet("file.go","file2.go"), differential.getChangedFiles());
     }
 }

--- a/src/test/resources/com/uber/jenkins/phabricator/conduit/ResponseWithChanges.json
+++ b/src/test/resources/com/uber/jenkins/phabricator/conduit/ResponseWithChanges.json
@@ -1,0 +1,15 @@
+{
+  "revisionID": "42",
+  "sourceControlBaseRevision": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+  "hello": "world",
+  "authorName": "aiden",
+  "authorEmail": "sc@ndella.com",
+  "changes": [
+    {
+      "currentPath": "file.go"
+    },
+    {
+      "currentPath": "file2.go"
+    }
+  ]
+}

--- a/src/test/resources/com/uber/jenkins/phabricator/conduit/validFetchDiffResponse.json
+++ b/src/test/resources/com/uber/jenkins/phabricator/conduit/validFetchDiffResponse.json
@@ -5,7 +5,18 @@
       "sourceControlBaseRevision": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
       "hello": "world",
       "authorName": "aiden",
-      "authorEmail": "sc@ndella.com"
+      "authorEmail": "sc@ndella.com",
+      "changes": [
+        {
+          "currentPath": "github.com/uber/go-torch/visualization/visualization.go"
+        },
+        {
+          "currentPath": "github.com/uber/go-torch/main.go"
+        },
+        {
+          "currentPath": "github.com/uber/go-torch/graph/graph.go"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
- only sends inline results for files that changed. Aggregate coverage metrics are still sent for everything
- Fixes #147 

Example:
I made a diff with just a single line change and tried out the flow using the existing plugin and this optimization.
Before
---------
<img width="1051" alt="screen shot 2016-04-26 at 11 25 04 pm" src="https://cloud.githubusercontent.com/assets/291148/14843727/75a12f14-0c07-11e6-9193-83fa1d30f28c.png">

After
-------
<img width="1050" alt="screen shot 2016-04-26 at 11 23 32 pm" src="https://cloud.githubusercontent.com/assets/291148/14843772/af17ffa2-0c07-11e6-8116-c35695d74589.png">
