### PR TITLE
Use filenames to compute set of files to publish line coverage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.9.5 (unreleased)
+
+* Use filenames to compute set of files to publish line coverage
+
 ### 1.9.4 (2016/04/28)
 
 * Publish inline coverage data only for changed files in the diff

--- a/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
@@ -35,11 +35,14 @@ import com.uber.jenkins.phabricator.unit.UnitTestProvider;
 import com.uber.jenkins.phabricator.utils.CommonUtils;
 import com.uber.jenkins.phabricator.utils.Logger;
 
+import org.apache.commons.io.FilenameUtils;
+
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -240,7 +243,19 @@ public class BuildResultProcessor {
             return;
         }
 
-        lineCoverage.keySet().retainAll(include);
+        Set<String> includeFileNames = new HashSet<String>();
+        for (String file : include) {
+            includeFileNames.add(FilenameUtils.getBaseName(file));
+        }
+
+        Set<String> includedLineCoverage = new HashSet<String>();
+        for (String file : lineCoverage.keySet()) {
+            if (includeFileNames.contains(FilenameUtils.getBaseName(file))) {
+                includedLineCoverage.add(file);
+            }
+        }
+
+        lineCoverage.keySet().retainAll(includedLineCoverage);
 
         harbormasterCoverage = new CoverageConverter().convert(lineCoverage);
     }

--- a/src/test/java/com/uber/jenkins/phabricator/BuildResultProcessorTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/BuildResultProcessorTest.java
@@ -73,6 +73,14 @@ public class BuildResultProcessorTest {
     }
 
     @Test
+    public void testProcessCoverageWithNonMatchingPathIncludes() throws Exception {
+        CoverageProvider provider = new FakeCoverageProvider(TestUtils.getDefaultLineCoverage());
+        processor.processCoverage(provider, Sets.newHashSet("somePath/file.go"));
+        assertNotNull(processor.getCoverage());
+        assertEquals("NCUC", processor.getCoverage().get("file.go"));
+    }
+
+    @Test
     public void testProcessEmptyCoverage() {
         CoverageProvider provider = new FakeCoverageProvider(null);
         processor.processCoverage(provider, Sets.<String>newHashSet());


### PR DESCRIPTION
- Use file names instead of paths to match coverage entries with changed files from diffs
- More reliable for projects like Android that do not use the full file path in the coverage.xml to specify classes