### PR TITLE
Fix line coverage being overwritten issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.9.6 (unreleased)
+
+* Fix incorrect line coverage when merging multiple cobertura reports
+
 ### 1.9.5 (2016/05/02)
 
 * Use filenames to compute set of files to publish line coverage

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
@@ -20,7 +20,6 @@
 
 package com.uber.jenkins.phabricator.coverage;
 
-import hudson.FilePath;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -30,11 +29,19 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+
+import hudson.FilePath;
 
 public class CoberturaXMLParser {
 
@@ -116,7 +123,9 @@ public class CoberturaXMLParser {
                                 continue;
                             }
 
-                            hitCounts.put(getIntValue(line, NODE_NUMBER), getIntValue(line, NODE_HITS));
+                            Integer lineNumber = getIntValue(line, NODE_NUMBER);
+                            int existingHits = hitCounts.containsKey(lineNumber) ? hitCounts.get(lineNumber) : 0;
+                            hitCounts.put(lineNumber, Math.max(existingHits, getIntValue(line, NODE_HITS)));
                         }
                         internalCounts.put(fileName, hitCounts);
                     }

--- a/src/test/resources/com/uber/jenkins/phabricator/coverage/go-torch-coverage_overwrite.xml
+++ b/src/test/resources/com/uber/jenkins/phabricator/coverage/go-torch-coverage_overwrite.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-03.dtd">
+<coverage line-rate="0" branch-rate="0" version="" timestamp="1440875217716">
+	<sources>
+		<source>/usr/local/Cellar/go/1.5/libexec/src</source>
+		<source>/Users/aiden/src/gocode/src</source>
+	</sources>
+	<packages>
+		<package name="github.com/uber/go-torch" line-rate="0" branch-rate="0" complexity="0">
+			<classes>
+				<class name="defaultPprofer" filename="github.com/uber/go-torch/main.go" line-rate="0" branch-rate="0" complexity="0">
+					<methods>
+						<method name="runPprofCommand" signature="" line-rate="0" branch-rate="0">
+							<lines>
+								<line number="212" hits="0"></line>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="212" hits="0"></line>
+					</lines>
+				</class>
+			</classes>
+		</package>
+	</packages>
+</coverage>


### PR DESCRIPTION
When there are more than 2 coverage report files, one overwrites the another, for example:

`cobertura1.xml`:
```
...
				<class name="defaultPprofer" filename="github.com/uber/go-torch/main.go" line-rate="0" branch-rate="0" complexity="0">
					<methods>
						<method name="runPprofCommand" signature="" line-rate="0" branch-rate="0">
							<lines>
								<line number="212" hits="1"></line>
							</lines>
						</method>
					</methods>
					<lines>
						<line number="212" hits="1"></line>
					</lines>
				</class>
```

`cobertura2.xml`:
```
...
				<class name="defaultPprofer" filename="github.com/uber/go-torch/main.go" line-rate="0" branch-rate="0" complexity="0">
					<methods>
						<method name="runPprofCommand" signature="" line-rate="0" branch-rate="0">
							<lines>
								<line number="212" hits="0"></line>
							</lines>
						</method>
					</methods>
					<lines>
						<line number="212" hits="0"></line>
					</lines>
				</class>
```

The computed line coverage shows that line 212 never get hit!! This pr will fix it!