### PR TITLE
Optional gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ work/
 target/
 .idea
 .DS_Store
+*.iml

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -220,7 +220,7 @@ public class PhabricatorNotifier extends Notifier {
         if (credentials == null) {
             throw new ConduitAPIException("No credentials configured for conduit");
         }
-        return new ConduitAPIClient(credentials.getUrl(), credentials.getToken().getPlainText());
+        return new ConduitAPIClient(credentials.getGateway(), credentials.getToken().getPlainText());
     }
 
     /**

--- a/src/main/java/com/uber/jenkins/phabricator/credentials/ConduitCredentials.java
+++ b/src/main/java/com/uber/jenkins/phabricator/credentials/ConduitCredentials.java
@@ -24,7 +24,10 @@ import com.cloudbees.plugins.credentials.Credentials;
 import hudson.util.Secret;
 
 public interface ConduitCredentials extends Credentials {
+
     Secret getToken();
+
+    String getGateway();
 
     String getUrl();
 }

--- a/src/main/java/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImpl.java
+++ b/src/main/java/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImpl.java
@@ -23,8 +23,10 @@ package com.uber.jenkins.phabricator.credentials;
 import com.cloudbees.plugins.credentials.CredentialsDescriptor;
 import com.cloudbees.plugins.credentials.NameWith;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.uber.jenkins.phabricator.utils.CommonUtils;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import hudson.util.Secret;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -35,22 +37,32 @@ public class ConduitCredentialsImpl extends BaseStandardCredentials implements C
     @NonNull
     private final Secret token;
 
+    @Nullable
+    private final String gateway;
+
     @NonNull
     private final String url;
 
     @DataBoundConstructor
     public ConduitCredentialsImpl(@CheckForNull String id,
                                   @NonNull @CheckForNull String url,
+                                  @Nullable String gateway,
                                   @CheckForNull String description,
                                   @CheckForNull String token) {
         super(id, description);
         this.url = url;
+        this.gateway = gateway;
         this.token = Secret.fromString(token);
     }
 
     @NonNull
     public String getUrl() {
         return url;
+    }
+
+    @Nullable
+    public String getGateway() {
+        return !CommonUtils.isBlank(gateway) ? gateway : getUrl();
     }
 
     @NonNull

--- a/src/main/resources/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImpl/config.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImpl/config.jelly
@@ -4,6 +4,9 @@
     <f:entry title="Phabricator URL" field="url">
         <f:textbox/>
     </f:entry>
+    <f:entry title="Phabricator Gateway (optional)" field="gateway">
+        <f:textbox/>
+    </f:entry>
     <f:entry title="Description" field="description">
         <f:textbox/>
     </f:entry>

--- a/src/main/resources/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImpl/help-gateway.html
+++ b/src/main/resources/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImpl/help-gateway.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Gateway is an optional configuration that can be used to point where your Conduit APIs are routed. If this not not defined, the Conduit client defaults all API calls to the URL defined with the credentials instead.</p>
+</div>

--- a/src/test/java/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImplTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImplTest.java
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Uber
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package com.uber.jenkins.phabricator.credentials;
+
+import com.uber.jenkins.phabricator.BuildIntegrationTest;
+import com.uber.jenkins.phabricator.utils.TestUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConduitCredentialsImplTest extends BuildIntegrationTest {
+
+    private static final String TEST_URL = "http://example.foobar";
+    private static final String TEST_GATEWAY = "http://example.weewar";
+
+    @Test
+    public void gatewayNotDefined() {
+        ConduitCredentials conduitCredentials = TestUtils.getConduitCredentials(TEST_URL, null);
+        assertEquals(conduitCredentials.getUrl(), conduitCredentials.getGateway());
+    }
+
+    @Test
+    public void gatewayDefinedDifferentValues() {
+        ConduitCredentials conduitCredentials = TestUtils.getConduitCredentials(TEST_URL, TEST_GATEWAY);
+        assertEquals(TEST_URL, conduitCredentials.getUrl());
+        assertEquals(TEST_GATEWAY, conduitCredentials.getGateway());
+    }
+
+    @Override
+    protected void addBuildStep() {
+    }
+}

--- a/src/test/java/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImplTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/credentials/ConduitCredentialsImplTest.java
@@ -46,5 +46,6 @@ public class ConduitCredentialsImplTest extends BuildIntegrationTest {
 
     @Override
     protected void addBuildStep() {
+        // Do nothing.
     }
 }

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -81,9 +81,10 @@ public class TestUtils {
     public static final String TEST_DIFFERENTIAL_ID = "123";
     public static final String TEST_CONDUIT_TOKEN = "notarealtoken";
     public static final String TEST_PHID = "PHID-not-real";
-    private static final String TEST_CREDENTIALS_ID = "not-a-real-uuid-for-credentials";
-    private static final String TEST_CONDUIT_URL = "http://example.gophers";
-    private static final String TEST_CONDUIT_GATEWAY = "http://foo.bar";
+    public static final String TEST_CREDENTIALS_ID = "not-a-real-uuid-for-credentials";
+    public static final String TEST_CONDUIT_URL = "http://example.gophers";
+    public static final String TEST_CONDUIT_GATEWAY = "http://foo.bar";
+    public static final String TEST_DESCRIPTION = "foobar";
     private static final String TEST_UNIT_NAMESPACE = "unit namespace";
     private static final String TEST_UNIT_NAME = "fake test name";
 
@@ -216,9 +217,12 @@ public class TestUtils {
         setEnvironmentVariables(j, getValidCommitEnvironment());
     }
 
+    public static ConduitCredentials getConduitCredentials(String url, String gateway) {
+        return new ConduitCredentialsImpl(TEST_CREDENTIALS_ID, url, gateway, TEST_DESCRIPTION, TEST_CONDUIT_TOKEN);
+    }
+
     public static ConduitCredentials getConduitCredentials(String conduitURI) {
-        return new ConduitCredentialsImpl(TEST_CREDENTIALS_ID, conduitURI, conduitURI, "description",
-                TestUtils.TEST_CONDUIT_TOKEN);
+        return getConduitCredentials(conduitURI, conduitURI);
     }
 
     public static ConduitCredentials getDefaultConduitCredentials() {

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -83,6 +83,7 @@ public class TestUtils {
     public static final String TEST_PHID = "PHID-not-real";
     private static final String TEST_CREDENTIALS_ID = "not-a-real-uuid-for-credentials";
     private static final String TEST_CONDUIT_URL = "http://example.gophers";
+    private static final String TEST_CONDUIT_GATEWAY = "http://foo.bar";
     private static final String TEST_UNIT_NAMESPACE = "unit namespace";
     private static final String TEST_UNIT_NAME = "fake test name";
 
@@ -216,7 +217,8 @@ public class TestUtils {
     }
 
     public static ConduitCredentials getConduitCredentials(String conduitURI) {
-        return new ConduitCredentialsImpl(TEST_CREDENTIALS_ID, conduitURI, "description", TestUtils.TEST_CONDUIT_TOKEN);
+        return new ConduitCredentialsImpl(TEST_CREDENTIALS_ID, conduitURI, TEST_CONDUIT_GATEWAY, "description",
+                TestUtils.TEST_CONDUIT_TOKEN);
     }
 
     public static ConduitCredentials getDefaultConduitCredentials() {

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -217,7 +217,7 @@ public class TestUtils {
     }
 
     public static ConduitCredentials getConduitCredentials(String conduitURI) {
-        return new ConduitCredentialsImpl(TEST_CREDENTIALS_ID, conduitURI, TEST_CONDUIT_GATEWAY, "description",
+        return new ConduitCredentialsImpl(TEST_CREDENTIALS_ID, conduitURI, conduitURI, "description",
                 TestUtils.TEST_CONDUIT_TOKEN);
     }
 


### PR DESCRIPTION
- Add gateway (optional) configuration to the plugin's Conduit credentials
- Default gateway to the url (required) if it is not defined
- Use the gateway to make Conduit API calls