### PR TITLE
Better inline coverage detection

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
@@ -281,7 +281,7 @@ public class BuildResultProcessor {
      *
      * @param coverageProvider a provider for the coverage data
      */
-    public void processCoverage(CoverageProvider coverageProvider, Set<String> include) {
+    void processCoverage(CoverageProvider coverageProvider) {
         if (coverageProvider == null) {
             logger.info(LOGGING_TAG, "No coverage provider available.");
             return;
@@ -291,20 +291,6 @@ public class BuildResultProcessor {
             logger.info(LOGGING_TAG, "No line coverage available to post to Harbormaster.");
             return;
         }
-
-        Set<String> includeFileNames = new HashSet<String>();
-        for (String file : include) {
-            includeFileNames.add(FilenameUtils.getBaseName(file));
-        }
-
-        Set<String> includedLineCoverage = new HashSet<String>();
-        for (String file : lineCoverage.keySet()) {
-            if (includeFileNames.contains(FilenameUtils.getBaseName(file))) {
-                includedLineCoverage.add(file);
-            }
-        }
-
-        lineCoverage.keySet().retainAll(includedLineCoverage);
 
         harbormasterCoverage = new CoverageConverter().convert(lineCoverage);
     }

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
@@ -79,7 +79,7 @@ public class CoberturaCoverageProvider extends CoverageProvider {
         return mLineCoverage;
     }
 
-    public Map<String, List<Integer>> parseReports(CoberturaXMLParser parser, File[] reports) {
+    Map<String, List<Integer>> parseReports(CoberturaXMLParser parser, File[] reports) {
         if (reports == null) {
             return null;
         }
@@ -144,7 +144,7 @@ public class CoberturaCoverageProvider extends CoverageProvider {
     private void computeLineCoverage() {
         FilePath workspace = getBuild().getWorkspace();
         File[] reports = getCoberturaReports(getBuild());
-        CoberturaXMLParser parser = new CoberturaXMLParser(workspace);
+        CoberturaXMLParser parser = new CoberturaXMLParser(workspace, getIncludeFileNames());
         mLineCoverage = parseReports(parser, reports);
     }
 

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoverageProvider.java
@@ -24,9 +24,23 @@ import hudson.model.AbstractBuild;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public abstract class CoverageProvider {
     private AbstractBuild<?, ?> build;
+    private Set<String> includeFileNames;
+
+    /**
+     * Set the list of file names to get coverage metrics for
+     * @param includeFileNames The list of file names to get coverage metrics for
+     */
+    public void setIncludeFileNames(Set<String> includeFileNames) {
+        this.includeFileNames = includeFileNames;
+    }
+
+    protected Set<String> getIncludeFileNames() {
+        return includeFileNames;
+    }
 
     /**
      * Set the owning build for this provider

--- a/src/test/java/com/uber/jenkins/phabricator/BuildResultProcessorTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/BuildResultProcessorTest.java
@@ -20,7 +20,6 @@
 
 package com.uber.jenkins.phabricator;
 
-import com.google.common.collect.Sets;
 import com.uber.jenkins.phabricator.conduit.ConduitAPIClient;
 import com.uber.jenkins.phabricator.conduit.ConduitAPIException;
 import com.uber.jenkins.phabricator.conduit.Differential;
@@ -76,38 +75,22 @@ public class BuildResultProcessorTest {
     @Test
     public void testProcessCoverage() throws Exception {
         CoverageProvider provider = new FakeCoverageProvider(TestUtils.getDefaultLineCoverage());
-        processor.processCoverage(provider, Sets.newHashSet("file.go"));
+        processor.processCoverage(provider);
         assertNotNull(processor.getCoverage());
         assertNotNull(processor.getCoverage().get("file.go"));
         assertEquals("NCUC", processor.getCoverage().get("file.go"));
     }
 
     @Test
-    public void testProcessCoverageWithNoIncludes() throws Exception {
-        CoverageProvider provider = new FakeCoverageProvider(TestUtils.getDefaultLineCoverage());
-        processor.processCoverage(provider, Sets.newHashSet("file2.go"));
-        assertNotNull(processor.getCoverage());
-        assertNull(processor.getCoverage().get("file.go"));
-    }
-
-    @Test
-    public void testProcessCoverageWithNonMatchingPathIncludes() throws Exception {
-        CoverageProvider provider = new FakeCoverageProvider(TestUtils.getDefaultLineCoverage());
-        processor.processCoverage(provider, Sets.newHashSet("somePath/file.go"));
-        assertNotNull(processor.getCoverage());
-        assertEquals("NCUC", processor.getCoverage().get("file.go"));
-    }
-
-    @Test
     public void testProcessEmptyCoverage() {
         CoverageProvider provider = new FakeCoverageProvider(null);
-        processor.processCoverage(provider, Sets.<String>newHashSet());
+        processor.processCoverage(provider);
         assertNull(processor.getCoverage());
     }
 
     @Test
     public void testProcessNullProvider() {
-        processor.processCoverage(null, Sets.<String>newHashSet());
+        processor.processCoverage(null);
         assertNull(processor.getCoverage());
     }
 

--- a/src/test/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParserPatameterizedTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParserPatameterizedTest.java
@@ -1,0 +1,82 @@
+// Copyright (c) 2015 Uber
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package com.uber.jenkins.phabricator.coverage;
+
+import com.google.common.io.Files;
+import hudson.FilePath;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(Parameterized.class)
+public class CoberturaXMLParserPatameterizedTest {
+
+    private static final String TEST_COVERAGE_PYTHON = "python-coverage.xml";
+
+    @Parameterized.Parameter
+    public Boolean createDirectory;
+
+    @Test
+    public void testDetectCoverageRoot() throws Exception {
+        File tmpDir = Files.createTempDir();
+        File example = new File(tmpDir, "example");
+
+        try {
+            CoberturaXMLParser parser = new CoberturaXMLParser(new FilePath(tmpDir), null);
+
+            if (createDirectory) {
+                example.mkdir();
+            }
+            Map<String, List<Integer>> lineCoverage = parser.parse(getResource(TEST_COVERAGE_PYTHON));
+            List<Integer> libCoverage = lineCoverage.get("example/lib.py");
+            assertEquals(1, libCoverage.get(2).longValue());
+            assertNull(libCoverage.get(1));
+        } finally {
+            if (createDirectory) {
+                example.delete();
+            }
+            tmpDir.delete();
+        }
+    }
+
+    private File getResource(String fileName) throws URISyntaxException {
+        return Paths.get(getClass().getResource(fileName).toURI()).toFile();
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {false},
+                {true},
+        });
+    }
+}


### PR DESCRIPTION
- Detect valid source root paths for every file included in the report. Cobertura reports containing files from multiple source roots are perfectly valid.
- Make inline coverage computation only happen for files changed as part of the diff. This means the plugin does not need to parse the reports in full for builds that are non differential. This is a performance improvement.
- Also cleaned up some tests which were parameterized, but did not need to be.