### PR TITLE
Make sure lint results follow phab api specs

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
@@ -41,15 +41,12 @@ import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
-import org.apache.commons.io.FilenameUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class BuildResultProcessor {
 
@@ -156,13 +153,15 @@ public class BuildResultProcessor {
                 String lint;
                 while ((lint = reader.readLine()) != null) {
                     JSONObject json = JSONObject.fromObject(lint);
+                    Object line = json.get("line");
+                    Object charPosition = json.get("char");
                     lintResults.add(new LintResult(
                             (String) json.get("name"),
                             (String) json.get("code"),
                             (String) json.get("severity"),
                             (String) json.get("path"),
-                            (Integer) json.get("line"),
-                            (Integer) json.get("char"),
+                            line == null ? null : (Integer) line,
+                            charPosition == null ? null : (Integer) charPosition,
                             (String) json.get("description")));
                 }
             }

--- a/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
@@ -153,16 +153,7 @@ public class BuildResultProcessor {
                 String lint;
                 while ((lint = reader.readLine()) != null) {
                     JSONObject json = JSONObject.fromObject(lint);
-                    Object line = json.get("line");
-                    Object charPosition = json.get("char");
-                    lintResults.add(new LintResult(
-                            (String) json.get("name"),
-                            (String) json.get("code"),
-                            (String) json.get("severity"),
-                            (String) json.get("path"),
-                            line == null ? null : (Integer) line,
-                            charPosition == null ? null : (Integer) charPosition,
-                            (String) json.get("description")));
+                    lintResults.add(LintResult.fromJsonObject(json));
                 }
             }
         } catch (JSONException e) {

--- a/src/main/java/com/uber/jenkins/phabricator/lint/LintResult.java
+++ b/src/main/java/com/uber/jenkins/phabricator/lint/LintResult.java
@@ -71,4 +71,16 @@ public class LintResult {
                 .element("char", charPosition)
                 .element("description", description);
     }
+
+    public static LintResult fromJsonObject(JSONObject json) {
+        String name = (String) json.get("name");
+        String code = (String) json.get("code");
+        String severity = (String) json.get("severity");
+        String path = (String) json.get("path");
+        Integer line = (Integer) json.opt("line");
+        Integer charPosition = (Integer) json.opt("char");
+        String description = (String) json.get("description");
+
+        return new LintResult(name, code, severity, path, line, charPosition, description);
+    }
 }

--- a/src/main/java/com/uber/jenkins/phabricator/lint/LintResult.java
+++ b/src/main/java/com/uber/jenkins/phabricator/lint/LintResult.java
@@ -42,11 +42,12 @@ public class LintResult {
     final String code;
     final String severity;
     final String path;
-    final int line;
-    final int charPosition; // NOTE "char" parameter in JSON
+    final Integer line;
+    final Integer charPosition; // NOTE "char" parameter in JSON
     final String description;
 
-    public LintResult(String name, String code, String severity, String path, int line, int charPosition, String description) {
+    public LintResult(String name, String code, String severity, String path, Integer line, Integer charPosition,
+                      String description) {
         this.name = name;
         this.code = code;
         this.severity = severity;

--- a/src/main/java/com/uber/jenkins/phabricator/lint/LintResult.java
+++ b/src/main/java/com/uber/jenkins/phabricator/lint/LintResult.java
@@ -79,7 +79,7 @@ public class LintResult {
         String path = (String) json.get("path");
         Integer line = (Integer) json.opt("line");
         Integer charPosition = (Integer) json.opt("char");
-        String description = (String) json.get("description");
+        String description = (String) json.opt("description");
 
         return new LintResult(name, code, severity, path, line, charPosition, description);
     }

--- a/src/test/java/com/uber/jenkins/phabricator/lint/LintResultTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/lint/LintResultTest.java
@@ -21,37 +21,30 @@
 package com.uber.jenkins.phabricator.lint;
 
 import net.sf.json.JSONObject;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class LintResultTest {
-    private LintResult results;
-
-    @Before
-    public void setUp() {
-        results = new LintResult("name", "code", "severity", "path", null, null, "description");
-    }
-
     @Test
     public void testToHarbormaster() {
+        LintResult results = new LintResult("name", "code", "severity", "path", 1, 2, "description");
         assertEquals(7, results.toHarbormaster().size());
     }
 
     @Test
     public void testFromJsonObject() {
-        results = LintResult.fromJsonObject(
+        LintResult results = LintResult.fromJsonObject(
                 JSONObject.fromObject(
                         "{ \"name\": \"NewApi\"," +
                                 "\"code\": \"_code\"," +
                                 "\"severity\": \"error\", " +
-                                "\"path\": \"foobar.java\","));
-        assertTrue(results.name == "NewApi");
-        assertTrue(results.code == "_code");
-        assertTrue(results.severity == "error");
-        assertTrue(results.path == "foobar.java");
+                                "\"path\": \"foobar.java\"}"));
+        assertEquals(results.name, "NewApi");
+        assertEquals(results.code, "_code");
+        assertEquals(results.severity, "error");
+        assertEquals(results.path, "foobar.java");
         assertTrue(results.line == null);
         assertTrue(results.charPosition == null);
         assertTrue(results.description == null);

--- a/src/test/java/com/uber/jenkins/phabricator/lint/LintResultTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/lint/LintResultTest.java
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 Uber
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package com.uber.jenkins.phabricator.lint;
+
+import net.sf.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class LintResultTest {
+    private LintResult results;
+
+    @Before
+    public void setUp() {
+        results = new LintResult("name", "code", "severity", "path", null, null, "description");
+    }
+
+    @Test
+    public void testToHarbormaster() {
+        assertEquals(7, results.toHarbormaster().size());
+    }
+
+    @Test
+    public void testFromJsonObject() {
+        results = LintResult.fromJsonObject(
+                JSONObject.fromObject(
+                        "{ \"name\": \"NewApi\"," +
+                                "\"code\": \"_code\"," +
+                                "\"severity\": \"error\", " +
+                                "\"path\": \"foobar.java\","));
+        assertTrue(results.name == "NewApi");
+        assertTrue(results.code == "_code");
+        assertTrue(results.severity == "error");
+        assertTrue(results.path == "foobar.java");
+        assertTrue(results.line == null);
+        assertTrue(results.charPosition == null);
+        assertTrue(results.description == null);
+    }
+}


### PR DESCRIPTION
Phab API specs does not require these 2 params. By forcefully casting the object we get back from json, we are inherently enforcing requirement.