### PR TITLE
Add diff id to PostbuildSummary

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorPostbuildSummaryAction.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorPostbuildSummaryAction.java
@@ -31,15 +31,17 @@ import org.kohsuke.stapler.export.ExportedBean;
 public class PhabricatorPostbuildSummaryAction implements Action {
     private final String iconPath;
     private final String url;
+    private final String diffID;
     private final String revisionID;
     private final String authorName;
     private final String authorEmail;
     private final String commitMessage;
 
-    public PhabricatorPostbuildSummaryAction(String iconPath, String phabricatorLink, String revisionID,
+    public PhabricatorPostbuildSummaryAction(String iconPath, String phabricatorLink, String diffID, String revisionID,
                                              String authorName, String authorEmail, String commitMessage) {
         this.iconPath = iconPath;
         this.url = phabricatorLink;
+        this.diffID = diffID;
         this.revisionID = revisionID;
         this.authorName = authorName;
         this.authorEmail = authorEmail;
@@ -69,6 +71,10 @@ public class PhabricatorPostbuildSummaryAction implements Action {
 
     @Exported public String getRevisionID() {
         return revisionID;
+    }
+
+    @Exported public String getDiffID() {
+        return diffID;
     }
 
     @Exported public String getAuthorName() {

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/Differential.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/Differential.java
@@ -49,6 +49,14 @@ public class Differential {
         this.rawJSON = rawJSON;
     }
 
+    public String getDIffID() {
+        String rawDiffId = (String) rawJSON.get("id");
+        if (rawDiffId == null || rawDiffId.equals("")) {
+            return null;
+        }
+        return rawDiffId;
+    }
+
     public String getRevisionID(boolean formatted) {
         String rawRevisionId = (String) rawJSON.get("revisionID");
         if (rawRevisionId == null || rawRevisionId.equals("")) {
@@ -85,6 +93,7 @@ public class Differential {
         return new PhabricatorPostbuildSummaryAction(
                 "phabricator.png",
                 getPhabricatorLink(phabricatorURL),
+                getDIffID(),
                 getRevisionID(true),
                 getAuthorName(),
                 getAuthorEmail(),

--- a/src/test/java/com/uber/jenkins/phabricator/conduit/DifferentialTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/conduit/DifferentialTest.java
@@ -32,7 +32,8 @@ import org.junit.Test;
 import java.io.IOException;
 
 public class DifferentialTest extends TestCase {
-    private static final String FAKE_DIFF_ID = "not-a-real-id";
+    private static final String FAKE_DIFF_ID = "not-a-real-diff-id";
+    private static final String FAKE_REVISION_ID = "not-a-real-revision-id";
 
     Differential differential;
 
@@ -43,12 +44,12 @@ public class DifferentialTest extends TestCase {
 
     @Test
     public void testFetchRevisionID() throws Exception {
-        assertEquals(FAKE_DIFF_ID, differential.getRevisionID(false));
+        assertEquals(FAKE_REVISION_ID, differential.getRevisionID(false));
     }
 
     @Test
     public void testGetPhabricatorLink() throws Exception {
-        assertTrue(differential.getPhabricatorLink("http://example.com").contains(FAKE_DIFF_ID));
+        assertTrue(differential.getPhabricatorLink("http://example.com").contains(FAKE_REVISION_ID));
     }
 
     @Test
@@ -86,8 +87,9 @@ public class DifferentialTest extends TestCase {
     @Test
     public void testGetSummaryMessage() throws Exception {
         PhabricatorPostbuildSummaryAction summary = differential.createSummary("http://example.com");
-        assertEquals("http://example.com/Dnot-a-real-id", summary.getUrl());
-        assertEquals("Dnot-a-real-id", summary.getRevisionID());
+        assertEquals("http://example.com/Dnot-a-real-revision-id", summary.getUrl());
+        assertEquals("not-a-real-diff-id", summary.getDiffID());
+        assertEquals("Dnot-a-real-revision-id", summary.getRevisionID());
         assertEquals("aiden", summary.getAuthorName());
         assertEquals("ai@uber.com", summary.getAuthorEmail());
     }

--- a/src/test/resources/com/uber/jenkins/phabricator/conduit/validDifferentialQueryResponse.json
+++ b/src/test/resources/com/uber/jenkins/phabricator/conduit/validDifferentialQueryResponse.json
@@ -1,5 +1,6 @@
 {
-  "revisionID": "not-a-real-id",
+  "id": "not-a-real-diff-id",
+  "revisionID": "not-a-real-revision-id",
   "branch": "a-branch-name",
   "sourceControlBaseRevision": "aaaaaaaa",
   "authorName": "aiden",


### PR DESCRIPTION
* Add diff id to Differential
* Report diff id in post build summary
* Correct unit test for revision id

It would be nice to provide differential id in Differential class. The
diff id is extracted from raw conduit json in the same way as revision
id, although it is also available from Jenkins params DIFF_ID.

Mean while, the differential test is updated to distinguish diff id
from revision id.