### PR TITLE
Add option to apply arc patch using the revision ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'java'
   id 'checkstyle'
-  id 'org.jenkins-ci.jpi' version '0.21.0'
+  id 'org.jenkins-ci.jpi' version '0.22.0'
   id 'net.saliman.cobertura' version '2.4.0'
   id 'com.github.kt3k.coveralls' version '2.7.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-bin.zip

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -74,7 +74,7 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
                                    boolean createBranch, boolean patchWithForceFlag,
                                    boolean useRevisionId) {
         this.createCommit = createCommit;
-        this.applyToMaster = applyToMaster;
+        this.applyToMaster = applyToMaster || useRevisionId; // Always use origin/master when useRevisionId is true
         this.skipForcedClean = skipForcedClean;
         this.createBranch = createBranch;
         this.patchWithForceFlag = patchWithForceFlag;

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -66,16 +66,19 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
     private final boolean skipForcedClean;
     private final boolean createBranch;
     private final boolean patchWithForceFlag;
+    private final boolean useRevisionId;
 
     @DataBoundConstructor
     public PhabricatorBuildWrapper(boolean createCommit, boolean applyToMaster,
                                    boolean skipForcedClean,
-                                   boolean createBranch, boolean patchWithForceFlag) {
+                                   boolean createBranch, boolean patchWithForceFlag,
+                                   boolean useRevisionId) {
         this.createCommit = createCommit;
         this.applyToMaster = applyToMaster;
         this.skipForcedClean = skipForcedClean;
         this.createBranch = createBranch;
         this.patchWithForceFlag = patchWithForceFlag;
+        this.useRevisionId = useRevisionId;
     }
 
     /** {@inheritDoc} */
@@ -148,9 +151,9 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
 
         final String conduitToken = this.getConduitToken(build.getParent(), logger);
         Task.Result result = new ApplyPatchTask(
-                logger, starter, baseCommit, diffID, conduitToken, getArcPath(),
+                logger, starter, baseCommit, diffID, diff.getRevisionID(true), conduitToken, getArcPath(),
                 DEFAULT_GIT_PATH, createCommit, skipForcedClean, createBranch,
-                patchWithForceFlag
+                patchWithForceFlag, useRevisionId
         ).run();
 
         if (result != Task.Result.SUCCESS) {

--- a/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
+++ b/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
@@ -34,6 +34,7 @@ public class ApplyPatchTask extends Task {
     private final LauncherFactory starter;
     private final String baseCommit;
     private final String diffID;
+    private final String revisionId;
     private final PrintStream logStream;
     private final String conduitToken;
     private final String arcPath;
@@ -42,15 +43,17 @@ public class ApplyPatchTask extends Task {
     private final boolean skipForcedClean;
     private final boolean createBranch;
     private final boolean patchWithForceFlag;
+    private final boolean useRevisionId;
 
     public ApplyPatchTask(Logger logger, LauncherFactory starter, String baseCommit,
-                          String diffID, String conduitToken, String arcPath,
+                          String diffID, String revisionId, String conduitToken, String arcPath,
                           String gitPath, boolean createCommit, boolean skipForcedClean,
-                          boolean createBranch, boolean patchWithForceFlag) {
+                          boolean createBranch, boolean patchWithForceFlag, boolean useRevisionId) {
         super(logger);
         this.starter = starter;
         this.baseCommit = baseCommit;
         this.diffID = diffID;
+        this.revisionId = revisionId;
         this.conduitToken = conduitToken;
         this.arcPath = arcPath;
         this.gitPath = gitPath;
@@ -58,6 +61,7 @@ public class ApplyPatchTask extends Task {
         this.skipForcedClean = skipForcedClean;
         this.createBranch = createBranch;
         this.patchWithForceFlag = patchWithForceFlag;
+        this.useRevisionId = useRevisionId;
 
         this.logStream = logger.getStream();
     }
@@ -84,13 +88,16 @@ public class ApplyPatchTask extends Task {
     @Override
     protected void execute() {
         try {
-            int exitCode = starter.launch()
-                    .cmds(Arrays.asList(gitPath, "reset", "--hard", baseCommit))
-                    .stdout(logStream)
-                    .join();
+            int exitCode;
+            if (!useRevisionId) {
+                exitCode = starter.launch()
+                        .cmds(Arrays.asList(gitPath, "reset", "--hard", baseCommit))
+                        .stdout(logStream)
+                        .join();
 
-            if (exitCode != 0) {
-                info("Got non-zero exit code resetting to base commit " + baseCommit + ": " + exitCode);
+                if (exitCode != 0) {
+                    info("Got non-zero exit code resetting to base commit " + baseCommit + ": " + exitCode);
+                }
             }
 
             if (!skipForcedClean) {
@@ -107,7 +114,15 @@ public class ApplyPatchTask extends Task {
                     .cmds(Arrays.asList(gitPath, "submodule", "update", "--init", "--recursive"))
                     .join();
 
-            List<String> arcPatchParams = new ArrayList<String>(Arrays.asList("--diff", diffID));
+            List<String> arcPatchParams;
+
+            if (useRevisionId) {
+                arcPatchParams = new ArrayList<String>();
+                arcPatchParams.add(revisionId);
+            } else {
+                arcPatchParams = new ArrayList<String>(Arrays.asList("--diff", diffID));
+            }
+
             if (!createCommit) {
                 arcPatchParams.add("--nocommit");
             }

--- a/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
+++ b/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
@@ -88,16 +88,13 @@ public class ApplyPatchTask extends Task {
     @Override
     protected void execute() {
         try {
-            int exitCode;
-            if (!useRevisionId) {
-                exitCode = starter.launch()
-                        .cmds(Arrays.asList(gitPath, "reset", "--hard", baseCommit))
-                        .stdout(logStream)
-                        .join();
+            int exitCode = starter.launch()
+                    .cmds(Arrays.asList(gitPath, "reset", "--hard", baseCommit))
+                    .stdout(logStream)
+                    .join();
 
-                if (exitCode != 0) {
-                    info("Got non-zero exit code resetting to base commit " + baseCommit + ": " + exitCode);
-                }
+            if (exitCode != 0) {
+                info("Got non-zero exit code resetting to base commit " + baseCommit + ": " + exitCode);
             }
 
             if (!skipForcedClean) {

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/config.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/config.jelly
@@ -20,4 +20,8 @@
            description="Skips running sanity checks (like base commit) when applying patch">
       <f:checkbox default="false" />
   </f:entry>
+  <f:entry title="Use Revision ID to patch" field="useRevisionId"
+             description="Use the revision ID to arc patch instead of the DIFF_ID and base commit">
+        <f:checkbox default="false" />
+    </f:entry>
 </j:jelly>

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
@@ -22,15 +22,25 @@ package com.uber.jenkins.phabricator;
 
 import com.google.common.collect.Lists;
 import com.uber.jenkins.phabricator.utils.TestUtils;
-import hudson.model.*;
+
 import net.sf.json.JSONObject;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.FreeStyleBuild;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Result;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
     private PhabricatorBuildWrapper wrapper;
@@ -39,6 +49,7 @@ public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
     public void setUp() throws Exception {
         p = createProject();
         wrapper = new PhabricatorBuildWrapper(
+                false,
                 false,
                 false,
                 false,

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -33,20 +33,10 @@ import com.uber.jenkins.phabricator.credentials.ConduitCredentials;
 import com.uber.jenkins.phabricator.credentials.ConduitCredentialsImpl;
 import com.uber.jenkins.phabricator.uberalls.UberallsClient;
 import com.uber.jenkins.phabricator.unit.UnitResult;
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.FreeStyleProject;
-import hudson.plugins.cobertura.CoberturaPublisher;
-import hudson.plugins.cobertura.renderers.SourceEncoding;
-import hudson.slaves.EnvironmentVariablesNodeProperty;
-import hudson.tasks.Publisher;
-import hudson.tasks.junit.JUnitResultArchiver;
-import hudson.util.CopyOnWriteMap;
+
 import net.sf.json.JSONObject;
 import net.sf.json.groovy.JsonSlurper;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
@@ -64,7 +54,23 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.cobertura.CoberturaPublisher;
+import hudson.plugins.cobertura.renderers.SourceEncoding;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.tasks.Publisher;
+import hudson.tasks.junit.JUnitResultArchiver;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -79,6 +85,7 @@ public class TestUtils {
     public static final String JUNIT_XML = "junit-test.xml";
 
     public static final String TEST_DIFFERENTIAL_ID = "123";
+    public static final String TEST_REVISION_ID = "D456";
     public static final String TEST_CONDUIT_TOKEN = "notarealtoken";
     public static final String TEST_PHID = "PHID-not-real";
     public static final String TEST_CREDENTIALS_ID = "not-a-real-uuid-for-credentials";


### PR DESCRIPTION
Adds a new config option `useRevisionId` to allow arc to apply a patch based on the revision instead of the `diff id` and `base commit`. This is useful for repositories that setup [staging areas](https://secure.phabricator.com/book/phabricator/article/harbormaster/) in a repository outside the main one.

Maintaining staging repositories outside the regular one have many advantages but the biggest one is the not polluting the repo tag space with phab diff tags that slow down checkouts and other git operations for everyone in that repo. This is especially visible in large monorepo like setups with a lot of source.

According to the harbormaster, arc can patch diffs even when the staging repositories are different when not using the `--diff` option. This change allows such behavior as an opt in without requiring the jobs to pass in any additional properties.