### PR TITLE
Fix Backwards compatibility for scmType field not existing.

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -232,6 +232,13 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
         }
     }
 
+    protected Object readResolve() {
+        if (scmType == null) {
+            scmType = "git";
+        }
+        return this;
+    }
+
     private void addShortText(final AbstractBuild build) {
         build.addAction(PhabricatorPostbuildAction.createShortText("master", null));
     }


### PR DESCRIPTION
Without this change legacy job configurations were triggering Null exception.