### PR TITLE
Make coverage report pattern configurable

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -77,12 +77,13 @@ public class PhabricatorNotifier extends Notifier {
     private final String lintFile;
     private final String lintFileSize;
     private final double coverageThreshold;
+    private final String coverageReportPattern;
     private UberallsClient uberallsClient;
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
     public PhabricatorNotifier(boolean commentOnSuccess, boolean uberallsEnabled, boolean coverageCheck,
-                               double coverageThreshold,
+                               double coverageThreshold, String coverageReportPattern,
                                boolean preserveFormatting, String commentFile, String commentSize,
                                boolean commentWithConsoleLinkOnFailure, boolean customComment, boolean processLint,
                                String lintFile, String lintFileSize) {
@@ -98,6 +99,7 @@ public class PhabricatorNotifier extends Notifier {
         this.customComment = customComment;
         this.processLint = processLint;
         this.coverageThreshold = coverageThreshold;
+        this.coverageReportPattern = coverageReportPattern;
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
@@ -312,6 +314,7 @@ public class PhabricatorNotifier extends Notifier {
 
         coverage.setBuild(build);
         coverage.setIncludeFileNames(includeFileNames);
+        coverage.setCoverageReportPattern(coverageReportPattern);
         if (coverage.hasCoverage()) {
             return coverage;
         } else {

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
@@ -49,7 +49,6 @@ import hudson.plugins.cobertura.targets.CoverageResult;
 public class CoberturaCoverageProvider extends CoverageProvider {
 
     private static final Logger LOGGER = Logger.getLogger(CoberturaCoverageProvider.class.getName());
-    private static final String COVERAGE_REPORT_FILTER = "**/coverage*.xml, **/cobertura*.xml";
 
     private CoverageResult mCoverageResult = null;
     private Map<String, List<Integer>> mLineCoverage = null;
@@ -158,7 +157,7 @@ public class CoberturaCoverageProvider extends CoverageProvider {
 
         if (moduleRoot != null) {
             try {
-                List<FilePath> reports = Arrays.asList(moduleRoot.list(COVERAGE_REPORT_FILTER));
+                List<FilePath> reports = Arrays.asList(moduleRoot.list(getCoverageReportPattern()));
 
                 int i = 0;
                 for (FilePath report : reports) {

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoverageProvider.java
@@ -29,6 +29,7 @@ import java.util.Set;
 public abstract class CoverageProvider {
     private AbstractBuild<?, ?> build;
     private Set<String> includeFileNames;
+    private String coverageReportPattern;
 
     /**
      * Set the list of file names to get coverage metrics for
@@ -52,6 +53,18 @@ public abstract class CoverageProvider {
 
     protected AbstractBuild getBuild() {
         return build;
+    }
+
+    /**
+     * Set the coverage report pattern to scan for
+     * @param coverageReportPattern The coverage report pattern to scan for
+     */
+    public void setCoverageReportPattern(String coverageReportPattern) {
+        this.coverageReportPattern = coverageReportPattern;
+    }
+
+    String getCoverageReportPattern() {
+        return coverageReportPattern;
     }
 
     public abstract Map<String, List<Integer>> readLineCoverage();

--- a/src/main/java/com/uber/jenkins/phabricator/provider/InstanceProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/provider/InstanceProvider.java
@@ -31,7 +31,7 @@ public class InstanceProvider<T> {
     private final String pluginName;
 
     /**
-     * Encapsulate lazilly loading a concrete implementation when a plugin is available
+     * Encapsulate lazily loading a concrete implementation when a plugin is available
      * @param jenkins the instance of Jenkins
      * @param pluginName the name of the plugin, e.g. "cobertura" or "junit" (maven name)
      * @param className the concrete class name (com.uber.phabricator...)

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorNotifier/config.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorNotifier/config.jelly
@@ -28,6 +28,10 @@
             description="Fail builds if coverage is below this threshold. Should be a negative number i.e. -5.0 as percent">
         <f:textbox default="0" />
     </f:entry>
+    <f:entry title="Coverage report pattern" field="coverageReportPattern"
+             description="The coverage xml report pattern. Use this if any jenkins coverage plugins are not applied.">
+      <f:textbox default="" />
+    </f:entry>
   </f:optionalBlock>
 
   <f:optionalBlock field="customComment" name="customComment" title="Add Custom Comment" inline="true" checked="${instance.isCustomComment()}">

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -39,6 +39,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 public class PhabricatorNotifierTest extends BuildIntegrationTest {
+
+    private static final String COVERAGE_REPORT_FILTER = "**/coverage*.xml, **/cobertura*.xml";
+
     private PhabricatorNotifier notifier;
 
     @Before
@@ -49,6 +52,7 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
                 true,
                 false,
                 0.0,
+                COVERAGE_REPORT_FILTER,
                 true,
                 ".phabricator-comment",
                 "1001",
@@ -272,6 +276,7 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
                 false,
                 false,
                 0.0,
+                COVERAGE_REPORT_FILTER,
                 true,
                 ".phabricator-comment",
                 "1000",
@@ -314,6 +319,7 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
             true,
             true,
             threshold,
+            COVERAGE_REPORT_FILTER,
             true,
             ".phabricator-comment",
             "1001",


### PR DESCRIPTION
This makes the coverage report pattern configurable by the user if they do not use any code coverage jenkins plugins.

This way, the plugin does not scan the entire workspace to find coverage files as it was doing before. Scanning the workspace fully can lead to slowdowns in large workspaces.