### PR TITLE
Show more info to the user when build failed due to the coverage drop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,4 @@ cache:
     - $HOME/.gradle/wrapper/
 
 addons:
-  hosts:
-    - phabplugintesthost
   hostname: phabplugintesthost

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,8 @@ cache:
   directories:
     - $HOME/.gradle/caches/modules-2/
     - $HOME/.gradle/wrapper/
+
+addons:
+  hosts:
+    - phabplugintesthost
+  hostname: phabplugintesthost

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       env: TASKS="cobertura coveralls"
 
 script:
-  - ./gradlew clean $TASKS --debug --stacktrace
+  - ./gradlew clean $TASKS --stacktrace
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       env: TASKS="cobertura coveralls"
 
 script:
-  - ./gradlew clean $TASKS --no-daemon --stacktrace
+  - ./gradlew clean $TASKS --no-daemon
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       env: TASKS="cobertura coveralls"
 
 script:
-  - ./gradlew clean $TASKS
+  - ./gradlew clean $TASKS --debug --stacktrace
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       env: TASKS="cobertura coveralls"
 
 script:
-  - ./gradlew clean $TASKS --stacktrace
+  - ./gradlew clean $TASKS --no-daemon --stacktrace
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
+++ b/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
@@ -95,14 +95,20 @@ class CommentBuilder {
             comment.append("Coverage remained the same (" + lineCoverageDisplay + "%)");
         }
 
-        // If coverage change is less than zero and dips below a certain threshold fail the build
-        if (coverageDelta < 0 && Math.abs(coverageDelta) > Math.abs(maximumCoverageDecreaseInPercent)) {
-            passCoverage = false;
-        }
-
         comment.append(" when pulling **" + branchName + "** into ");
         comment.append(baseCommit.substring(0, 7));
         comment.append(".");
+
+        // If coverage change is less than zero and dips below a certain threshold fail the build
+        if (coverageDelta < 0 && Math.abs(coverageDelta) > Math.abs(maximumCoverageDecreaseInPercent)) {
+            passCoverage = false;
+            String message = "Build failed because coverage decreased more than allowed " +
+                             Math.abs(maximumCoverageDecreaseInPercent) + "%";
+            logger.info(UBERALLS_TAG, message);
+            comment.append("\n");
+            comment.append(message);
+            comment.append(".");
+        }
 
         return passCoverage;
     }


### PR DESCRIPTION
When code coverage drop exceeds some configured limit - the plugin will
mark the build as failed, but it's hard to figure out the reason of the
failure. To address this issue added logging of this event and also
sending of the reason of the failure as part of the comment posted to
phabricator.