### PR TITLE
Make httpcore 4.3 be forced only in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,10 @@ dependencies {
 }
 
 configurations.all {
-  resolutionStrategy {
-    force 'org.apache.httpcomponents:httpclient:4.3:tests'
+  if (it.name.toLowerCase().contains("test")) {
+    resolutionStrategy {
+      force 'org.apache.httpcomponents:httpclient:4.3:tests'
+    }
   }
 }
 


### PR DESCRIPTION
Without this change, the generated `hpi` package can fail at runtime with the wrong version of httpcore being used