### PR TITLE
Fix bug to allow phab to process multi line lint reports.

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/BuildResultProcessor.java
@@ -152,12 +152,14 @@ public class BuildResultProcessor {
             if (input != null && input.length() > 0) {
                 lintResults = new LintResults();
                 BufferedReader reader = new BufferedReader(new StringReader(input));
-
-                String lint;
-                while ((lint = reader.readLine()) != null) {
+                String lint = "";
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    lint += line;
                     try {
                         JSONObject json = JSONObject.fromObject(lint);
                         lintResults.add(LintResult.fromJsonObject(json));
+                        lint = "";
                     } catch (JSONException e) {
                         e.printStackTrace(logger.getStream());
                     }

--- a/src/test/java/com/uber/jenkins/phabricator/BuildResultProcessorTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/BuildResultProcessorTest.java
@@ -135,19 +135,10 @@ public class BuildResultProcessorTest {
 
     @Test
     public void testProcessLintViolationsWithNonJsonLines() throws Exception {
-        String content = "{\"name\": \"Syntax Error\"," +
-                "\"code\": \"EXAMPLE\"," +
-                "\"severity\": \"error\"," +
-                "\"path\": \"path/to/example\"," +
-                "\"line\": 17," +
-                "\"char\": 3}\n" +
-                "{This is not json}\n" +
-                "{\"name\": \"Syntax Error\"," +
-                "\"code\": \"EXAMPLE\"," +
-                "\"severity\": \"error\"," +
-                "\"path\": \"path/to/example\"," +
-                "\"line\": 20," +
-                "\"char\": 30}\n";
+        String content = "{ \"name\": \"PotentialLeak\", \"code\": \"\", \"severity\": \"error\", \"path\": \"Main.java\", \"line\": 21, \"char\": 5, \"description\": \"Potential leak detected.\n" +
+                "Features should only be in memory when they are attached.\" }\n" +
+                "{ \"name\": \"PotentialLeak\", \"code\": \"\", \"severity\": \"error\", \"path\": \"App.java\", \"line\": 22, \"char\": 5, \"description\": \"Potential leak detected.\n" +
+                "Features should only be in memory when they are attached.\" }\n";
 
         ConduitAPIClient conduitAPIClient = new ConduitAPIClient(null, null) {
             @Override


### PR DESCRIPTION
Looks like the old phab plugin couldn't parse results split up over multiple lines. I followed TDD with the bellow example and made it work for the two results, which initially were zero, as the trailing } was cut off.