### PR TITLE
Fix issues with configurable coverage report pattern

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -385,6 +385,11 @@ public class PhabricatorNotifier extends Notifier {
     }
 
     @SuppressWarnings("UnusedDeclaration")
+    public String getCoverageReportPattern() {
+        return coverageReportPattern;
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
     public boolean isPreserveFormatting() {
         return preserveFormatting;
     }

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
@@ -155,9 +155,10 @@ public class CoberturaCoverageProvider extends CoverageProvider {
         final File buildCoberturaDir = build.getRootDir();
         FilePath buildTarget = new FilePath(buildCoberturaDir);
 
-        if (moduleRoot != null) {
+        String coverageReportPattern = getCoverageReportPattern();
+        if (moduleRoot != null && coverageReportPattern != null) {
             try {
-                List<FilePath> reports = Arrays.asList(moduleRoot.list(getCoverageReportPattern()));
+                List<FilePath> reports = Arrays.asList(moduleRoot.list(coverageReportPattern));
 
                 int i = 0;
                 for (FilePath report : reports) {

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorNotifier/config.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorNotifier/config.jelly
@@ -34,7 +34,7 @@
     </f:entry>
     <f:entry title="Coverage report pattern" field="coverageReportPattern"
              description="The coverage xml report pattern. Use this if any jenkins coverage plugins are not applied.">
-      <f:textbox default="" />
+      <f:textbox default="**/coverage*.xml, **/cobertura*.xml" />
     </f:entry>
   </f:optionalBlock>
 

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -47,22 +47,7 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
     @Before
     public void setUp() throws IOException {
         p = createProject();
-        notifier = new PhabricatorNotifier(
-                false,
-                true,
-                false,
-                0.0,
-                0.0,
-                COVERAGE_REPORT_FILTER,
-                true,
-                ".phabricator-comment",
-                "1001",
-                false,
-                true,
-                true,
-                ".phabricator-lint",
-                "10000"
-        );
+        notifier = getDefaultTestNotifierWithCoverageReportPattern(COVERAGE_REPORT_FILTER);
     }
 
     @Test
@@ -234,6 +219,17 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
     }
 
     @Test
+    public void testPostCoverageWithoutPublisherWithNullReportPattern() throws Exception {
+        notifier = getDefaultTestNotifierWithCoverageReportPattern(null);
+
+        TestUtils.addCopyBuildStep(p, "src/coverage/" + TestUtils.COBERTURA_XML, CoberturaXMLParser.class, "go-torch-coverage.xml");
+
+        FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), null, new JSONObject());
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertLogContains("No cobertura results found", build);
+    }
+
+    @Test
     public void testPostUnit() throws Exception {
         TestUtils.addCopyBuildStep(p, TestUtils.JUNIT_XML, JUnitTestProvider.class, "go-torch-junit.xml");
         p.getPublishersList().add(TestUtils.getDefaultXUnitPublisher());
@@ -325,6 +321,25 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
             true,
             ".phabricator-lint",
             "10000"
+        );
+    }
+
+    private PhabricatorNotifier getDefaultTestNotifierWithCoverageReportPattern(String coverageReportPattern) {
+        return new PhabricatorNotifier(
+                false,
+                true,
+                false,
+                0.0,
+                0.0,
+                coverageReportPattern,
+                true,
+                ".phabricator-comment",
+                "1001",
+                false,
+                true,
+                true,
+                ".phabricator-lint",
+                "10000"
         );
     }
 }


### PR DESCRIPTION
The field was missing a getter so it didn't show the value in jenkins
job configuration. Also by default it was set to null which caused a
NPE. Added check for null and default value for the property.