### PR TITLE
CommentBuilder: Fix possible NPE

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
+++ b/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
@@ -117,8 +117,10 @@ class CommentBuilder {
     }
 
     private boolean isBuildFailingCoverageCheck(double lineCoveragePercent, double coverageDelta) {
-        return coverageCheckSettings.isCoverageCheckEnabled() && lineCoveragePercent < coverageCheckSettings.getMinCoverageInPercent() &&
-               coverageDelta < 0 && Math.abs(coverageDelta) > Math.abs(coverageCheckSettings.getMaxCoverageDecreaseInPercent());
+        return (coverageCheckSettings != null
+            && coverageCheckSettings.isCoverageCheckEnabled()
+            && lineCoveragePercent < coverageCheckSettings.getMinCoverageInPercent()
+            && coverageDelta < 0 && Math.abs(coverageDelta) > Math.abs(coverageCheckSettings.getMaxCoverageDecreaseInPercent()));
     }
 
     void processBuildResult(boolean commentOnSuccess, boolean commentWithConsoleLinkOnFailure, boolean runHarbormaster) {

--- a/src/test/java/com/uber/jenkins/phabricator/CommentBuilderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/CommentBuilderTest.java
@@ -136,6 +136,27 @@ public class CommentBuilderTest {
     }
 
     @Test
+    public void testProcessWithoutCoverageCheckSettings() {
+        CommentBuilder commenter = new CommentBuilder(
+            logger,
+            Result.SUCCESS,
+            TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 50.0f), // 50% drop
+            FAKE_BUILD_URL,
+            false,
+            null // coverageCheckSettings
+        );
+
+        boolean passCoverage = commenter.processParentCoverage(TestUtils.getDefaultCodeCoverageMetrics(),
+            TestUtils.TEST_SHA, FAKE_BRANCH_NAME);
+        String comment = commenter.getComment();
+
+        // Should not fail if we don't have coverageCheckSettings.
+        assertTrue(passCoverage);
+        assertThat(comment, containsString("decreased (-50.000%)"));
+        assertFalse(comment.contains("Build failed because coverage is lower"));
+    }
+
+    @Test
     public void testProcessBuildResultSuccess() {
         commenter.processBuildResult(false, false, true);
         assertTrue(


### PR DESCRIPTION
This fixes an NPE in isBuildFailingCoverageCheck if
coverageCheckSettings is unset. We saw the following failure in a build,

    java.lang.NullPointerException
            at com.uber.jenkins.phabricator.CommentBuilder.isBuildFailingCoverageCheck(CommentBuilder.java:120)
            at com.uber.jenkins.phabricator.CommentBuilder.processParentCoverage(CommentBuilder.java:104)
            at com.uber.jenkins.phabricator.BuildResultProcessor.processParentCoverage(BuildResultProcessor.java:103)
            at com.uber.jenkins.phabricator.PhabricatorNotifier.perform(PhabricatorNotifier.java:228)
            at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
            at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:779)
            at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:720)
            at hudson.model.Build$BuildExecution.post2(Build.java:186)
            at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:665)
            at hudson.model.Run.execute(Run.java:1753)
            at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
            at hudson.model.ResourceController.execute(ResourceController.java:98)
            at hudson.model.Executor.run(Executor.java:405)

coverageCheckSettings is the only thing I see there that could be null.