### PR TITLE
Mask http core in gradle build file.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ jenkinsPlugin {
   url = 'https://wiki.jenkins-ci.org/display/JENKINS/Phabricator+Differential+Plugin'
   gitHubUrl = 'https://github.com/uber/phabricator-jenkins-plugin'
   shortName = 'phabricator-plugin'
+  maskClasses = 'org.apache.http.'
 
   developers {
     developer {


### PR DESCRIPTION
This used to be done in maven, otherwise we get conflicts between jenkins plugin and jenkins http lib versions during runtime.