### PR TITLE
Set default value for coverage report pattern

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
@@ -49,6 +49,7 @@ import hudson.plugins.cobertura.targets.CoverageResult;
 public class CoberturaCoverageProvider extends CoverageProvider {
 
     private static final Logger LOGGER = Logger.getLogger(CoberturaCoverageProvider.class.getName());
+    private static final String DEFAULT_COVERAGE_REPORT_PATTERN = "**/coverage*.xml, **/cobertura*.xml";
 
     private CoverageResult mCoverageResult = null;
     private Map<String, List<Integer>> mLineCoverage = null;
@@ -156,7 +157,10 @@ public class CoberturaCoverageProvider extends CoverageProvider {
         FilePath buildTarget = new FilePath(buildCoberturaDir);
 
         String coverageReportPattern = getCoverageReportPattern();
-        if (moduleRoot != null && coverageReportPattern != null) {
+        if (coverageReportPattern == null || coverageReportPattern.isEmpty()) {
+            coverageReportPattern = DEFAULT_COVERAGE_REPORT_PATTERN;
+        }
+        if (moduleRoot != null) {
             try {
                 List<FilePath> reports = Arrays.asList(moduleRoot.list(coverageReportPattern));
 

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -219,8 +219,22 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
     }
 
     @Test
-    public void testPostCoverageWithoutPublisherWithNullReportPattern() throws Exception {
-        notifier = getDefaultTestNotifierWithCoverageReportPattern(null);
+    public void testPostCoverageWithoutPublisherWithEmptyReportPattern() throws Exception {
+        String[] emptyPatterns = {null, ""};
+        for (String emptyPattern : emptyPatterns) {
+            notifier = getDefaultTestNotifierWithCoverageReportPattern(emptyPattern);
+
+            TestUtils.addCopyBuildStep(p, "src/coverage/" + TestUtils.COBERTURA_XML, CoberturaXMLParser.class, "go-torch-coverage.xml");
+
+            FreeStyleBuild build = buildWithConduit(getFetchDiffResponse(), null, new JSONObject());
+            assertEquals(Result.SUCCESS, build.getResult());
+            assertLogContains("Publishing coverage data to Harbormaster for 3 files", build);
+        }
+    }
+
+    @Test
+    public void testPostCoverageWithoutPublisherWithNoFilesMatchingReportPattern() throws Exception {
+        notifier = getDefaultTestNotifierWithCoverageReportPattern("*.html");
 
         TestUtils.addCopyBuildStep(p, "src/coverage/" + TestUtils.COBERTURA_XML, CoberturaXMLParser.class, "go-torch-coverage.xml");
 


### PR DESCRIPTION
To fix issues with backward compatibility if coverage report pattern is
null or empty we will use the default value "**/coverage*.xml,
**/cobertura*.xml"