### PR TITLE
Make sure CoberturaXMLParser is not trying to access external network…

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
@@ -41,6 +41,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import com.google.common.collect.ImmutableMap;
+
 import hudson.FilePath;
 
 public class CoberturaXMLParser {
@@ -54,17 +56,15 @@ public class CoberturaXMLParser {
     private static final String NODE_HITS = "hits";
     private static final String EMPTY_XML = "<?xml version='1.0' encoding='UTF-8'?>";
     private static final Logger LOGGER = Logger.getLogger(CoberturaXMLParser.class.getName());
-    private static final Map<String, String> dtdMap = new HashMap<String, String>();
+    private static final Map<String, String> dtdMap = ImmutableMap.<String, String>builder()
+        .put("http://cobertura.sourceforge.net/xml/coverage-01.dtd1", "coverage-01.dtd")
+        .put("http://cobertura.sourceforge.net/xml/coverage-02.dtd1", "coverage-02.dtd")
+        .put("http://cobertura.sourceforge.net/xml/coverage-03.dtd1", "coverage-03.dtd")
+        .put("http://cobertura.sourceforge.net/xml/coverage-04.dtd1", "coverage-04.dtd")
+        .build();
 
     private final FilePath workspace;
     private final Set<String> includeFileNames;
-
-    static {
-        dtdMap.put("http://cobertura.sourceforge.net/xml/coverage-01.dtd1", "coverage-01.dtd");
-        dtdMap.put("http://cobertura.sourceforge.net/xml/coverage-02.dtd1", "coverage-02.dtd");
-        dtdMap.put("http://cobertura.sourceforge.net/xml/coverage-03.dtd1", "coverage-03.dtd");
-        dtdMap.put("http://cobertura.sourceforge.net/xml/coverage-04.dtd1", "coverage-04.dtd");
-    }
 
     CoberturaXMLParser(FilePath workspace, Set<String> includeFileNames) {
         this.workspace = workspace;

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
@@ -89,6 +89,7 @@ public class CoberturaXMLParser {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         DocumentBuilder db;
         Map<NodeList, List<String>> coverageData = new HashMap<NodeList, List<String>>();
+
         for (File file : files) {
             InputStream is = null;
             try {

--- a/src/main/resources/com/uber/jenkins/phabricator/coverage/coverage-01.dtd
+++ b/src/main/resources/com/uber/jenkins/phabricator/coverage/coverage-01.dtd
@@ -1,0 +1,40 @@
+<!-- Portions (C) International Organization for Standardization 1986:
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+
+<!ELEMENT coverage (packages)>
+<!ATTLIST coverage src CDATA "">
+
+<!ELEMENT packages (package*)>
+
+<!ELEMENT package (classes)>
+<!ATTLIST package name        CDATA #REQUIRED>
+<!ATTLIST package line-rate   CDATA #REQUIRED>
+<!ATTLIST package branch-rate CDATA #REQUIRED>
+<!ATTLIST package complexity  CDATA #REQUIRED>
+
+<!ELEMENT classes (class*)>
+
+<!ELEMENT class (methods,lines)>
+<!ATTLIST class name        CDATA #REQUIRED>
+<!ATTLIST class filename    CDATA #REQUIRED>
+<!ATTLIST class line-rate   CDATA #REQUIRED>
+<!ATTLIST class branch-rate CDATA #REQUIRED>
+<!ATTLIST class complexity  CDATA #REQUIRED>
+
+<!ELEMENT methods (method*)>
+
+<!ELEMENT method (lines)>
+<!ATTLIST method name        CDATA #REQUIRED>
+<!ATTLIST method signature   CDATA #REQUIRED>
+<!ATTLIST method line-rate   CDATA #REQUIRED>
+<!ATTLIST method branch-rate CDATA #REQUIRED>
+
+<!ELEMENT lines (line*)>
+
+<!ELEMENT line EMPTY>
+<!ATTLIST line number CDATA #REQUIRED>
+<!ATTLIST line hits   CDATA #REQUIRED>
+<!ATTLIST line branch CDATA "false">

--- a/src/main/resources/com/uber/jenkins/phabricator/coverage/coverage-02.dtd
+++ b/src/main/resources/com/uber/jenkins/phabricator/coverage/coverage-02.dtd
@@ -1,0 +1,47 @@
+<!-- Portions (C) International Organization for Standardization 1986:
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+
+<!ELEMENT coverage (sources?,packages)>
+<!ATTLIST coverage line-rate   CDATA #REQUIRED>
+<!ATTLIST coverage branch-rate CDATA #REQUIRED>
+<!ATTLIST coverage version     CDATA #REQUIRED>
+<!ATTLIST coverage timestamp   CDATA #REQUIRED>
+
+<!ELEMENT sources (source*)>
+
+<!ELEMENT source (#PCDATA)>
+
+<!ELEMENT packages (package*)>
+
+<!ELEMENT package (classes)>
+<!ATTLIST package name        CDATA #REQUIRED>
+<!ATTLIST package line-rate   CDATA #REQUIRED>
+<!ATTLIST package branch-rate CDATA #REQUIRED>
+<!ATTLIST package complexity  CDATA #REQUIRED>
+
+<!ELEMENT classes (class*)>
+
+<!ELEMENT class (methods,lines)>
+<!ATTLIST class name        CDATA #REQUIRED>
+<!ATTLIST class filename    CDATA #REQUIRED>
+<!ATTLIST class line-rate   CDATA #REQUIRED>
+<!ATTLIST class branch-rate CDATA #REQUIRED>
+<!ATTLIST class complexity  CDATA #REQUIRED>
+
+<!ELEMENT methods (method*)>
+
+<!ELEMENT method (lines)>
+<!ATTLIST method name        CDATA #REQUIRED>
+<!ATTLIST method signature   CDATA #REQUIRED>
+<!ATTLIST method line-rate   CDATA #REQUIRED>
+<!ATTLIST method branch-rate CDATA #REQUIRED>
+
+<!ELEMENT lines (line*)>
+
+<!ELEMENT line EMPTY>
+<!ATTLIST line number CDATA #REQUIRED>
+<!ATTLIST line hits   CDATA #REQUIRED>
+<!ATTLIST line branch CDATA "false">

--- a/src/main/resources/com/uber/jenkins/phabricator/coverage/coverage-03.dtd
+++ b/src/main/resources/com/uber/jenkins/phabricator/coverage/coverage-03.dtd
@@ -1,0 +1,55 @@
+<!-- Portions (C) International Organization for Standardization 1986:
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+
+<!ELEMENT coverage (sources?,packages)>
+<!ATTLIST coverage line-rate   CDATA #REQUIRED>
+<!ATTLIST coverage branch-rate CDATA #REQUIRED>
+<!ATTLIST coverage version     CDATA #REQUIRED>
+<!ATTLIST coverage timestamp   CDATA #REQUIRED>
+
+<!ELEMENT sources (source*)>
+
+<!ELEMENT source (#PCDATA)>
+
+<!ELEMENT packages (package*)>
+
+<!ELEMENT package (classes)>
+<!ATTLIST package name        CDATA #REQUIRED>
+<!ATTLIST package line-rate   CDATA #REQUIRED>
+<!ATTLIST package branch-rate CDATA #REQUIRED>
+<!ATTLIST package complexity  CDATA #REQUIRED>
+
+<!ELEMENT classes (class*)>
+
+<!ELEMENT class (methods,lines)>
+<!ATTLIST class name        CDATA #REQUIRED>
+<!ATTLIST class filename    CDATA #REQUIRED>
+<!ATTLIST class line-rate   CDATA #REQUIRED>
+<!ATTLIST class branch-rate CDATA #REQUIRED>
+<!ATTLIST class complexity  CDATA #REQUIRED>
+
+<!ELEMENT methods (method*)>
+
+<!ELEMENT method (lines)>
+<!ATTLIST method name        CDATA #REQUIRED>
+<!ATTLIST method signature   CDATA #REQUIRED>
+<!ATTLIST method line-rate   CDATA #REQUIRED>
+<!ATTLIST method branch-rate CDATA #REQUIRED>
+
+<!ELEMENT lines (line*)>
+
+<!ELEMENT line (conditions*)>
+<!ATTLIST line number CDATA #REQUIRED>
+<!ATTLIST line hits   CDATA #REQUIRED>
+<!ATTLIST line branch CDATA "false">
+<!ATTLIST line condition-coverage CDATA "100%">
+
+<!ELEMENT conditions (condition*)>
+
+<!ELEMENT condition EMPTY>
+<!ATTLIST condition number CDATA #REQUIRED>
+<!ATTLIST condition type CDATA #REQUIRED>
+<!ATTLIST condition coverage CDATA #REQUIRED>

--- a/src/main/resources/com/uber/jenkins/phabricator/coverage/coverage-04.dtd
+++ b/src/main/resources/com/uber/jenkins/phabricator/coverage/coverage-04.dtd
@@ -1,0 +1,61 @@
+<!-- Portions (C) International Organization for Standardization 1986:
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+
+  <!ELEMENT coverage (sources?,packages)>
+  <!ATTLIST coverage line-rate        CDATA #REQUIRED>
+  <!ATTLIST coverage branch-rate      CDATA #REQUIRED>
+  <!ATTLIST coverage lines-covered    CDATA #REQUIRED>
+  <!ATTLIST coverage lines-valid      CDATA #REQUIRED>
+  <!ATTLIST coverage branches-covered CDATA #REQUIRED>
+  <!ATTLIST coverage branches-valid   CDATA #REQUIRED>
+  <!ATTLIST coverage complexity       CDATA #REQUIRED>
+  <!ATTLIST coverage version          CDATA #REQUIRED>
+  <!ATTLIST coverage timestamp        CDATA #REQUIRED>
+
+  <!ELEMENT sources (source*)>
+
+  <!ELEMENT source (#PCDATA)>
+
+  <!ELEMENT packages (package*)>
+
+  <!ELEMENT package (classes)>
+  <!ATTLIST package name        CDATA #REQUIRED>
+  <!ATTLIST package line-rate   CDATA #REQUIRED>
+  <!ATTLIST package branch-rate CDATA #REQUIRED>
+  <!ATTLIST package complexity  CDATA #REQUIRED>
+
+  <!ELEMENT classes (class*)>
+
+  <!ELEMENT class (methods,lines)>
+  <!ATTLIST class name        CDATA #REQUIRED>
+  <!ATTLIST class filename    CDATA #REQUIRED>
+  <!ATTLIST class line-rate   CDATA #REQUIRED>
+  <!ATTLIST class branch-rate CDATA #REQUIRED>
+  <!ATTLIST class complexity  CDATA #REQUIRED>
+
+  <!ELEMENT methods (method*)>
+
+  <!ELEMENT method (lines)>
+  <!ATTLIST method name        CDATA #REQUIRED>
+  <!ATTLIST method signature   CDATA #REQUIRED>
+  <!ATTLIST method line-rate   CDATA #REQUIRED>
+  <!ATTLIST method branch-rate CDATA #REQUIRED>
+  <!ATTLIST method complexity  CDATA #REQUIRED>
+
+  <!ELEMENT lines (line*)>
+
+  <!ELEMENT line (conditions*)>
+  <!ATTLIST line number CDATA #REQUIRED>
+  <!ATTLIST line hits   CDATA #REQUIRED>
+  <!ATTLIST line branch CDATA "false">
+  <!ATTLIST line condition-coverage CDATA "100%">
+
+  <!ELEMENT conditions (condition*)>
+
+  <!ELEMENT condition EMPTY>
+  <!ATTLIST condition number CDATA #REQUIRED>
+  <!ATTLIST condition type CDATA #REQUIRED>
+  <!ATTLIST condition coverage CDATA #REQUIRED>


### PR DESCRIPTION
Xerces is actually trying to download document schema from internet, eg.: `http://cobertusa.sourceforge.net/xml/coverage-03.dtd` and from time to time it fails and this results in failed coverage data upload to phabricator.

We "statically" downloaded DTD file and return them back if parser request, if it requests something unknown then we return empty document
