### PR TITLE
Oraclejdk7 is no longer available, Oracle deprecated it this summer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - jdk: openjdk7
       env: TASKS="check"
-    - jdk: oraclejdk7
+    - jdk: oraclejdk8
       env: TASKS="check"
     - jdk: oraclejdk8
       env: TASKS="cobertura coveralls"


### PR DESCRIPTION
oraclejdk7 tests will fail because it is no longer available