### PR TITLE
Openjdk7 has issues on trusty platform, temporary fix issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   include:
     - jdk: openjdk7
       env: TASKS="check"
+      dist: precise
     - jdk: oraclejdk7
       env: TASKS="check"
     - jdk: oraclejdk8


### PR DESCRIPTION
This should fix travis build failure related to: `Caused by: java.security.NoSuchProviderException: no such provider: SunEC` - ubuntu backported patch from openjdk8 which broke openjdk7.