### PR TITLE
Bulk file check on slaves

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
@@ -118,6 +118,21 @@ public class CoberturaXMLParser {
             NodeList classes = entry.getKey();
             List<String> sourceDirs = entry.getValue();
 
+            // Collect all filenames
+            List<String> fileNames = new LinkedList<String>();
+            for (int i = 0; i < classes.getLength(); i++) {
+                Node classNode = classes.item(i);
+                String fileName = classNode.getAttributes().getNamedItem(NODE_FILENAME).getTextContent();
+
+                if (includeFileNames != null && !includeFileNames.contains(FilenameUtils.getName(fileName))) {
+                    continue;
+                }
+                fileNames.add(fileName);
+            }
+
+            // Make multiple guesses on which of the `sourceDirs` contains files in question
+            Map<String, String> detectedSourceRoots = new PathResolver(workspace, sourceDirs).chooseMulti(fileNames);
+
             // Loop over all files in the coverage report
             for (int i = 0; i < classes.getLength(); i++) {
                 Node classNode = classes.item(i);

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
@@ -118,7 +118,7 @@ public class CoberturaXMLParser {
             NodeList classes = entry.getKey();
             List<String> sourceDirs = entry.getValue();
 
-            // Collect all filenames
+            // Collect all filenames in coverage report
             List<String> fileNames = new LinkedList<String>();
             for (int i = 0; i < classes.getLength(); i++) {
                 Node classNode = classes.item(i);
@@ -131,7 +131,7 @@ public class CoberturaXMLParser {
             }
 
             // Make multiple guesses on which of the `sourceDirs` contains files in question
-            Map<String, String> detectedSourceRoots = new PathResolver(workspace, sourceDirs).chooseMulti(fileNames);
+            Map<String, String> detectedSourceRoots = new PathResolver(workspace, sourceDirs).choose(fileNames);
 
             // Loop over all files in the coverage report
             for (int i = 0; i < classes.getLength(); i++) {
@@ -142,9 +142,7 @@ public class CoberturaXMLParser {
                     continue;
                 }
 
-                // Make a guess on which of the `sourceDirs` contains the file in question
-                String detectedSourceRoot = new PathResolver(workspace, sourceDirs).choose(fileName);
-                fileName = join(detectedSourceRoot, fileName);
+                fileName = join(detectedSourceRoots.get(fileName), fileName);
 
                 SortedMap<Integer, Integer> hitCounts = internalCounts.get(fileName);
                 if (hitCounts == null) {

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
@@ -120,6 +120,7 @@ public class CoberturaXMLParser {
 
             // Collect all filenames in coverage report
             List<String> fileNames = new ArrayList<String>();
+            List<NodeList> childNodes = new ArrayList<NodeList>();
             for (int i = 0; i < classes.getLength(); i++) {
                 Node classNode = classes.item(i);
                 String fileName = classNode.getAttributes().getNamedItem(NODE_FILENAME).getTextContent();
@@ -128,20 +129,15 @@ public class CoberturaXMLParser {
                     continue;
                 }
                 fileNames.add(fileName);
+                childNodes.add(classNode.getChildNodes());
             }
 
             // Make multiple guesses on which of the `sourceDirs` contains files in question
             Map<String, String> detectedSourceRoots = new PathResolver(workspace, sourceDirs).choose(fileNames);
 
-            // Loop over all files in the coverage report
-            for (int i = 0; i < classes.getLength(); i++) {
-                Node classNode = classes.item(i);
-                String fileName = classNode.getAttributes().getNamedItem(NODE_FILENAME).getTextContent();
-
-                if (includeFileNames != null && !includeFileNames.contains(FilenameUtils.getName(fileName))) {
-                    continue;
-                }
-
+            // Loop over all files which are needed for coverage report
+            for (int i = 0; i < fileNames.size(); i++) {
+                String fileName = fileNames.get(i);
                 fileName = join(detectedSourceRoots.get(fileName), fileName);
 
                 SortedMap<Integer, Integer> hitCounts = internalCounts.get(fileName);
@@ -149,7 +145,7 @@ public class CoberturaXMLParser {
                     hitCounts = new TreeMap<Integer, Integer>();
                 }
 
-                NodeList children = classNode.getChildNodes();
+                NodeList children = childNodes.get(i);
                 for (int j = 0; j < children.getLength(); j++) {
                     Node child = children.item(j);
 

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaXMLParser.java
@@ -119,7 +119,7 @@ public class CoberturaXMLParser {
             List<String> sourceDirs = entry.getValue();
 
             // Collect all filenames in coverage report
-            List<String> fileNames = new LinkedList<String>();
+            List<String> fileNames = new ArrayList<String>();
             for (int i = 0; i < classes.getLength(); i++) {
                 Node classNode = classes.item(i);
                 String fileName = classNode.getAttributes().getNamedItem(NODE_FILENAME).getTextContent();

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/PathResolver.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/PathResolver.java
@@ -21,9 +21,15 @@
 package com.uber.jenkins.phabricator.coverage;
 
 import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
 
 import java.io.IOException;
+import java.io.File;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 public class PathResolver {
     private final FilePath root;
@@ -42,19 +48,73 @@ public class PathResolver {
      * additional `source` directories in version 4.0.3
      */
     public String choose(String filename) {
-        for (String sourceDir : candidates) {
-            FilePath candidate = new FilePath(root, sourceDir);
-            candidate = new FilePath(candidate, filename);
-            try {
+        String result = null;
+        try {
+            if (candidates.size() > 0) {
+                return root.act(new PathResolverChooseMultiCallable(candidates, new LinkedList<String).(filename)).get(filename);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * Using the workspace's root FilePath and files that is presumed to exist on the node running the tests,
+     * recurse over the `sources` provided by Cobertura and look for a combination where the file exists.
+     *
+     * This is a heuristic, and not perfect, to overcome changes to Python's coverage.py module which introduced
+     * additional `source` directories in version 4.0.3
+     */
+
+    public Map<String, String> chooseMulti(List<String> filenames) {
+       return new HashMap<String, String>();
+    }
+
+    private static final class PathResolverChooseCallable extends MasterToSlaveFileCallable<String> {
+        private final List<String> candidates;
+        private final String filename;
+
+        private PathResolverChooseCallable(List<String> candidates, String filename) {
+            this.candidates = candidates;
+            this.filename = filename;
+        }
+
+        public String invoke(File f, VirtualChannel channel) {
+            for (String sourceDir : candidates) {
+                File candidate = new File(f, sourceDir);
+                candidate = new File(candidate, filename);
                 if (candidate.exists()) {
                     return sourceDir;
                 }
-            } catch (IOException e) {
-                e.printStackTrace();
-            } catch (InterruptedException e) {
-                e.printStackTrace();
             }
+            return null;
         }
-        return null;
+    }
+
+    private static final class PathResolverChooseMultiCallable extends MasterToSlaveFileCallable<Map<String, String>> {
+        private final List<String> candidates;
+        private final List<String> filenames;
+
+        private PathResolverChooseMultiCallable(List<String> candidates, List<String> filenames) {
+            this.candidates = candidates;
+            this.filenames = filenames;
+        }
+
+        public Map<String, String> invoke(File f, VirtualChannel channel) {
+            Map<String, String> res = new HashMap<String, String>();
+            for (String filename : filenames) {
+                for (String sourceDir : candidates) {
+                    File candidate = new File(f, sourceDir);
+                    candidate = new File(candidate, filename);
+                    if (candidate.exists()) {
+                        res.put(filename, sourceDir);
+                    }
+                }
+            }
+            return res;
+        }
     }
 }

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/PathResolver.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/PathResolver.java
@@ -28,12 +28,8 @@ import java.io.IOException;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 public class PathResolver {
     private final FilePath root;

--- a/src/test/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProviderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProviderTest.java
@@ -25,7 +25,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import hudson.FilePath;
 import hudson.plugins.cobertura.CoberturaBuildAction;
 import hudson.plugins.cobertura.Ratio;
 import hudson.plugins.cobertura.targets.CoverageMetric;

--- a/src/test/java/com/uber/jenkins/phabricator/coverage/PathResolverTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/coverage/PathResolverTest.java
@@ -70,14 +70,8 @@ public class PathResolverTest {
 
         Map<String, String> chosen = new PathResolver(new FilePath(tmpDir), dirs).choose(filenames);
 
-        if (candidates.isEmpty()) {
-            for (String filename : filenames) {
-                assertNull(chosen.get(filename));
-            }
-        } else {
-            for (String filename  : filenames) {
-                assertEquals(expectedResult.get(filename), chosen.get(filename));
-            }
+        for (String filename  : filenames) {
+            assertEquals(expectedResult.get(filename), chosen.get(filename));
         }
     }
 


### PR DESCRIPTION
When phabricator jenkins plugin does coverage file parse it checks each covered file on slave which source directory contains source file this can be expensive if you have large code base or large amount if covered source directories or when you have large latency between master<->slave (on another coast), this actually happened with one of project where such "check" was taking 1.5h to completed. 
Instead of checking individual files - we collect all needed files and make bulk request. `PathResolverChooseMultiCallable` is serialized by jenkins and sent to be executed on slave which does this efficiently and returns back result. This might cause extreme memory usage for extremely large code base if such case happens - bulk request will have to be chunked