### PR TITLE
Read InputStream content fully

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/RemoteFileFetcher.java
+++ b/src/main/java/com/uber/jenkins/phabricator/RemoteFileFetcher.java
@@ -24,6 +24,7 @@ import com.uber.jenkins.phabricator.utils.CommonUtils;
 import com.uber.jenkins.phabricator.utils.Logger;
 import hudson.FilePath;
 
+import org.apache.commons.io.IOUtils;
 import java.io.IOException;
 
 import static java.lang.Integer.parseInt;
@@ -75,7 +76,7 @@ public class RemoteFileFetcher {
             maxLength = (int)source.length();
         }
         byte[] buffer = new byte[maxLength];
-        source.read().read(buffer, 0, maxLength);
+        IOUtils.read(source.read(), buffer);
 
         return new String(buffer);
     }

--- a/src/test/java/com/uber/jenkins/phabricator/RemoteFileFetcherTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/RemoteFileFetcherTest.java
@@ -36,6 +36,7 @@ import org.jvnet.hudson.test.TestBuilder;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import org.apache.commons.lang.StringUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -76,15 +77,20 @@ public class RemoteFileFetcherTest {
 
     @Test
     public void testSingleFile() throws Exception {
-        testWithContent("hello, world");
+        testWithContent("hello, world", "1000");
     }
 
     @Test
     public void testUTF8File() throws Exception {
-        testWithContent("こんにちは世界");
+        testWithContent("こんにちは世界", "1000");
     }
 
-    private void testWithContent(String content) throws Exception {
+    @Test
+    public void testLargeFile() throws Exception {
+        testWithContent(StringUtils.repeat("a", 10000), "10000");
+    }
+
+    private void testWithContent(String content, String len) throws Exception {
         final String fileName = "just-a-test.txt";
         project.getBuildersList().add(echoBuilder(fileName, content));
         FreeStyleBuild build = getBuild();
@@ -93,7 +99,7 @@ public class RemoteFileFetcherTest {
                 build.getWorkspace(),
                 logger,
                 fileName,
-                "1000"
+                len
         );
 
         assertEquals(content, fetcher.getRemoteFile());
@@ -102,7 +108,7 @@ public class RemoteFileFetcherTest {
                 build.getWorkspace(),
                 logger,
                 "*.txt",
-                "1000"
+                len
         );
 
         assertEquals(content, fetcher.getRemoteFile());


### PR DESCRIPTION
Unfortunetely not sure if it is possible to cover with unit test because during unit testing FilePath.read() is backed by FileInputStream but when it is actually executed on slave only first 8192 bytes are read hence comments are truncated... It looks like such chunks are delivered by jenkins Pipe implementation. Let's use Commons read() which tries to read content fully and avoid loop checking read lenght