### PR TITLE
Fix failing test when using Jenkins 2.6

### DIFF
--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperTest.java
@@ -27,6 +27,7 @@ import net.sf.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -143,7 +144,11 @@ public class PhabricatorBuildWrapperTest extends BuildIntegrationTest {
         FreeStyleBuild upstream = buildWithConduit(getFetchDiffResponse(), null, null, true);
         assertNull(PhabricatorBuildWrapper.getUpstreamRun(build));
 
-        build.getAction(CauseAction.class).getCauses().add((new Cause.UpstreamCause(upstream)));
+        List<Cause> causes = build.getAction(CauseAction.class).getCauses();
+        ArrayList<Cause> newCauses = new ArrayList<Cause>(causes);
+        newCauses.add((new Cause.UpstreamCause(upstream)));
+        build.replaceAction(new CauseAction(newCauses));
+
         assertEquals(upstream, PhabricatorBuildWrapper.getUpstreamRun(build));
     }
 


### PR DESCRIPTION
[`CauseAction#getCauses()`](http://javadoc.jenkins-ci.org/hudson/model/CauseAction.html#getCauses--) was made immutable in https://github.com/jenkinsci/jenkins/commit/4adee7597aad7a338db8d3eb320575ae618a8c81 / [jenkins-1.655](https://jenkins.io/changelog-old/#v1.655) which was causing the test which mutates the list to fail.

This change replaces the `CauseAction` in the build altogether with the new set of `Causes`

Note: This was the only failing test I found when updating Jenkins to 2.6, which happens to be required to upload to the plugin repository #189