### PR TITLE
Emit absolute values for aggregation

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
@@ -213,6 +213,8 @@ public class CoberturaCoverageProvider extends CoverageProvider {
                 classesCoverage,
                 methodCoverage,
                 lineCoverage,
+                result.getCoverage(CoverageMetric.LINE).numerator,
+                result.getCoverage(CoverageMetric.LINE).denominator,
                 conditionalCoverage
         );
     }

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CodeCoverageMetrics.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CodeCoverageMetrics.java
@@ -26,16 +26,20 @@ public class CodeCoverageMetrics {
     private float classesCoveragePercent = -1;
     private float methodCoveragePercent = -1;
     private float lineCoveragePercent = -1;
+    private float linesCovered = -1;
+    private float linesTested = -1;
     private float conditionalCoveragePercent = -1;
 
     public CodeCoverageMetrics(float packagesCoveragePercent, float filesCoveragePercent,
                                float classesCoveragePercent, float methodCoveragePercent, float lineCoveragePercent,
-                               float conditionalCoveragePercent) {
+                               float linesCovered, float linesTested, float conditionalCoveragePercent) {
         this.packagesCoveragePercent = packagesCoveragePercent;
         this.filesCoveragePercent = filesCoveragePercent;
         this.classesCoveragePercent = classesCoveragePercent;
         this.methodCoveragePercent = methodCoveragePercent;
         this.lineCoveragePercent = lineCoveragePercent;
+        this.linesCovered = linesCovered;
+        this.linesTested = linesTested;
         this.conditionalCoveragePercent = conditionalCoveragePercent;
     }
 
@@ -63,6 +67,14 @@ public class CodeCoverageMetrics {
         return lineCoveragePercent;
     }
 
+    public float getLinesCovered() {
+        return linesCovered;
+    }
+
+    public float getLinesTested() {
+        return linesTested;
+    }
+
     public float getConditionalCoveragePercent() {
         return conditionalCoveragePercent;
     }
@@ -79,6 +91,10 @@ public class CodeCoverageMetrics {
         sb.append(methodCoveragePercent);
         sb.append(", line coverage = ");
         sb.append(lineCoveragePercent);
+        sb.append(", lines covered = ");
+        sb.append(linesCovered);
+        sb.append(", lines tested = ");
+        sb.append(linesTested);
         sb.append(", conditional coverage = ");
         sb.append(conditionalCoveragePercent);
         return sb.toString();

--- a/src/main/java/com/uber/jenkins/phabricator/uberalls/UberallsClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/uberalls/UberallsClient.java
@@ -47,6 +47,8 @@ public class UberallsClient {
     public static final String CLASSES_COVERAGE_KEY = "classesCoverage";
     public static final String METHOD_COVERAGE_KEY = "methodCoverage";
     public static final String LINE_COVERAGE_KEY = "lineCoverage";
+    public static final String LINES_COVERED_KEY = "linesCovered";
+    public static final String LINES_TESTED_KEY = "linesTested";
     public static final String CONDITIONAL_COVERAGE_KEY = "conditionalCoverage";
 
     private static final String TAG = "uberalls-client";
@@ -86,6 +88,8 @@ public class UberallsClient {
                     ((Double) coverage.getDouble(CLASSES_COVERAGE_KEY)).floatValue(),
                     ((Double) coverage.getDouble(METHOD_COVERAGE_KEY)).floatValue(),
                     ((Double) coverage.getDouble(LINE_COVERAGE_KEY)).floatValue(),
+                    ((Double) coverage.getDouble(LINES_COVERED_KEY)).floatValue(),
+                    ((Double) coverage.getDouble(LINES_TESTED_KEY)).floatValue(),
                     ((Double) coverage.getDouble(CONDITIONAL_COVERAGE_KEY)).floatValue());
         } catch (Exception e) {
             e.printStackTrace(logger.getStream());
@@ -105,6 +109,8 @@ public class UberallsClient {
             params.put(CLASSES_COVERAGE_KEY, codeCoverageMetrics.getClassesCoveragePercent());
             params.put(METHOD_COVERAGE_KEY, codeCoverageMetrics.getMethodCoveragePercent());
             params.put(LINE_COVERAGE_KEY, codeCoverageMetrics.getLineCoveragePercent());
+            params.put(LINES_COVERED_KEY, codeCoverageMetrics.getLinesCovered());
+            params.put(LINES_TESTED_KEY, codeCoverageMetrics.getLinesTested());
             params.put(CONDITIONAL_COVERAGE_KEY, codeCoverageMetrics.getConditionalCoveragePercent());
 
             try {

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -127,7 +127,7 @@ public class TestUtils {
                                                              float conditionalCoveragePercent) {
         return spy(new CodeCoverageMetrics(packagesCoveragePercent, filesCoveragePercent,
                 classesCoveragePercent, methodCoveragePercent, lineCoveragePercent,
-                conditionalCoveragePercent));
+                10.0f, 10.0f, conditionalCoveragePercent));
     }
 
     public static CodeCoverageMetrics getDefaultCodeCoverageMetrics() {
@@ -143,12 +143,14 @@ public class TestUtils {
                 classesCoverage,
                 methodCoverage,
                 linesCoverage,
+                10.0f,
+                10.0f,
                 0.0f
         );
     }
 
     public static CodeCoverageMetrics getEmptyCoverageMetrics() {
-        return new CodeCoverageMetrics(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+        return new CodeCoverageMetrics(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
     }
 
     public static JSONObject getJSONFromFile(Class klass, String filename) throws IOException {


### PR DESCRIPTION
This is a proposal/WIP to emit absolute line coverage numbers in addition to the current percentages. This information is useful for aggregating coverage data from multiple sources.

A corresponding diff in Uberalls would be responsible for consuming and persisting this data.

I haven't considered backwards compatibility issues. I imagine we would want to keep the legacy constructors around for anyone with custom reporter implementations.

I have no intention of landing this -- anyone is free to pick it up. This would certainly need some additional testing (in addition to fixing the couple of failures).