### PR TITLE
[Phabricator diff] Change condition for provided path for arcanist to prevent not finding the binary.

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -51,6 +51,7 @@ import hudson.util.RunList;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import java.nio.*;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -326,7 +326,7 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
      */
     private String getArcPath() {
         final String providedPath = getDescriptor().getArcPath();
-        
+
         if (CommonUtils.isBlank(providedPath) || Files.notExists(Paths.get(providedPath))) {
             return "arc";
         }

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -51,7 +51,7 @@ import hudson.util.RunList;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.nio.*;
+import java.nio.file.*;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -327,7 +327,7 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
     private String getArcPath() {
         final String providedPath = getDescriptor().getArcPath();
         
-        if (CommonUtils.isBlank(providedPath) || Files.notExists(providedPath)) {
+        if (CommonUtils.isBlank(providedPath) || Files.notExists(Paths.get(providedPath))) {
             return "arc";
         }
         return providedPath;

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -325,7 +325,8 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
      */
     private String getArcPath() {
         final String providedPath = getDescriptor().getArcPath();
-        if (CommonUtils.isBlank(providedPath)) {
+        
+        if (CommonUtils.isBlank(providedPath) || Files.notExists(providedPath)) {
             return "arc";
         }
         return providedPath;


### PR DESCRIPTION
Right now if I set up Path for my arcanist binary in Phabricator DIFF part of this plugin it uses the explicit way to call it.
`/anyrootfolder/whatever/waytoarc/arcanist/bin/arc patch --someflag`

This is huge problem, because if you take for instance macbook machine, it has no /opt folder at all and it is tricky to setup this path (well not tricky at all, I just believe there should be no opt folder on macOS, but creating the folder requires admin rights and it's a bit dangerous...)

I inserted another condition to prevent the behaviour when the path is not available... 
