### PR TITLE
Add newline before link in phab comments

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
+++ b/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
@@ -173,7 +173,7 @@ class CommentBuilder {
      * Add a build link to the comment
      */
     void addBuildLink() {
-        comment.append(String.format(" %s for more details.", buildURL));
+        comment.append(String.format("\nSee %s for more details.", buildURL));
     }
 
     /**


### PR DESCRIPTION
Go from this:
![screenshot 2018-07-25 at 4 01 54 pm](https://user-images.githubusercontent.com/212338/43232149-6412e5a0-9024-11e8-9858-38c5b0ddb573.png)

To this:
![screenshot 2018-07-25 at 4 03 42 pm](https://user-images.githubusercontent.com/212338/43232146-6094391a-9024-11e8-8e3d-f04e35e47712.png)

Hooray!