### PR TITLE
Update Gradle JPI plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'java'
   id 'checkstyle'
-  id 'org.jenkins-ci.jpi' version '0.26.0'
+  id 'org.jenkins-ci.jpi' version '0.27.0'
   id 'net.saliman.cobertura' version '2.5.4'
   id 'com.github.kt3k.coveralls' version '2.8.2'
 }


### PR DESCRIPTION
Changelog: https://github.com/jenkinsci/gradle-jpi-plugin/blob/master/CHANGELOG.md#0270-2018-07-05

This primarily fixes compatibility with Gradle 4.8