### PR TITLE
Call arc with --conduit-uri flag

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -175,8 +175,9 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
             }
 
             final String conduitToken = this.getConduitToken(build.getParent(), logger);
+            final String conduitUrl = this.getPhabricatorURL(build.getParent());
             Task.Result result = new ApplyPatchTask(
-                    logger, starter, baseCommit, diffID, conduitToken, getArcPath(),
+                    logger, starter, baseCommit, diffID, conduitUrl, conduitToken, getArcPath(),
                     DEFAULT_GIT_PATH, createCommit, skipForcedClean, createBranch,
                     patchWithForceFlag, scmType
             ).run();

--- a/src/main/java/com/uber/jenkins/phabricator/conduit/ArcanistClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/conduit/ArcanistClient.java
@@ -30,12 +30,14 @@ import java.io.PrintStream;
 public class ArcanistClient {
     private final String arcPath;
     private final String methodName;
+    private final String conduitUrl;
     private final String conduitToken;
     private final String[] arguments;
 
-    public ArcanistClient(String arcPath, String methodName, String conduitToken, String... arguments) {
+    public ArcanistClient(String arcPath, String methodName, String conduitUrl, String conduitToken, String... arguments) {
         this.arcPath = arcPath;
         this.methodName = methodName;
+        this.conduitUrl = conduitUrl;
         this.conduitToken = conduitToken;
         this.arguments = arguments;
     }
@@ -43,6 +45,10 @@ public class ArcanistClient {
     private ArgumentListBuilder getConduitCommand() {
         ArgumentListBuilder builder = new ArgumentListBuilder(this.arcPath, this.methodName);
         builder.add(arguments);
+
+        if (!CommonUtils.isBlank(this.conduitUrl)) {
+            builder.add("--conduit-uri=" + this.conduitUrl);
+        }
 
         if (!CommonUtils.isBlank(this.conduitToken)) {
             builder.addMasked("--conduit-token=" + this.conduitToken);

--- a/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
+++ b/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
@@ -35,6 +35,7 @@ public class ApplyPatchTask extends Task {
     private final String baseCommit;
     private final String diffID;
     private final PrintStream logStream;
+    private final String conduitUrl;
     private final String conduitToken;
     private final String arcPath;
     private final boolean createCommit;
@@ -45,14 +46,15 @@ public class ApplyPatchTask extends Task {
     private final String scmType;
 
     public ApplyPatchTask(Logger logger, LauncherFactory starter, String baseCommit,
-                          String diffID, String conduitToken, String arcPath,
-                          String gitPath, boolean createCommit, boolean skipForcedClean,
-                          boolean createBranch, boolean patchWithForceFlag,
-                          String scmType) {
+                          String diffID, String conduitUrl, String conduitToken,
+                          String arcPath, String gitPath, boolean createCommit,
+                          boolean skipForcedClean, boolean createBranch,
+                          boolean patchWithForceFlag, String scmType) {
         super(logger);
         this.starter = starter;
         this.baseCommit = baseCommit;
         this.diffID = diffID;
+        this.conduitUrl = conduitUrl;
         this.conduitToken = conduitToken;
         this.arcPath = arcPath;
         this.gitPath = gitPath;
@@ -132,6 +134,7 @@ public class ApplyPatchTask extends Task {
             ArcanistClient arc = new ArcanistClient(
                     arcPath,
                     "patch",
+                    conduitUrl,
                     conduitToken,
                     arcPatchParams.toArray(new String[arcPatchParams.size()]));
 

--- a/src/test/java/com/uber/jenkins/phabricator/conduit/ArcanistClientTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/conduit/ArcanistClientTest.java
@@ -33,7 +33,7 @@ public class ArcanistClientTest {
 
     @Test
     public void testEcho() throws Exception {
-        ArcanistClient client = new ArcanistClient("echo", "hello", null);
+        ArcanistClient client = new ArcanistClient("echo", "hello", null, null);
 
         int result = client.callConduit(getLauncher().launch(), System.err);
         assertEquals(result, 0);
@@ -41,7 +41,7 @@ public class ArcanistClientTest {
 
     @Test
     public void testEchoWithToken() throws Exception {
-        ArcanistClient client = new ArcanistClient("echo", "tokentest", "notarealtoken");
+        ArcanistClient client = new ArcanistClient("echo", "tokentest", "testurl", "notarealtoken");
 
         int result = client.callConduit(getLauncher().launch(), System.err);
         assertEquals(result, 0);

--- a/src/test/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTaskTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTaskTest.java
@@ -45,6 +45,7 @@ public class ApplyPatchTaskTest {
                 TestUtils.createLauncherFactory(j),
                 TestUtils.TEST_SHA,
                 TestUtils.TEST_DIFFERENTIAL_ID,
+                TestUtils.TEST_CONDUIT_URL,
                 TestUtils.TEST_CONDUIT_TOKEN,
                 "echo", "true", false, false, false, false, "svn");
         Task.Result result = task.run();
@@ -70,6 +71,7 @@ public class ApplyPatchTaskTest {
                 TestUtils.createLauncherFactory(j),
                 TestUtils.TEST_SHA,
                 TestUtils.TEST_DIFFERENTIAL_ID,
+                TestUtils.TEST_CONDUIT_URL,
                 TestUtils.TEST_CONDUIT_TOKEN,
                 arcPath,
                 gitPath, // git path


### PR DESCRIPTION
This removes the requirement of having Phabricator url configured in `~/.arcrc` or `.arcconfig` in project

Closes #262