### PR TITLE
Fallback to `GIT_URL_1`

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -116,7 +116,10 @@ public class PhabricatorNotifier extends Notifier implements SimpleBuildStep {
         Logger logger = new Logger(listener.getLogger());
 
         final String branch = environment.get("GIT_BRANCH");
-        final String gitUrl = environment.get("GIT_URL");
+        String gitUrl = environment.get("GIT_URL");
+        if (gitUrl == null) {
+            gitUrl = environment.get("GIT_URL_1");
+        }
 
         final UberallsClient uberallsClient = getUberallsClient(logger, gitUrl, branch);
 


### PR DESCRIPTION
In order to support staging repositories, fallback to `GIT_URL_1` if `GIT_URL` is null.

Fixes #277