### PR TITLE
Send linesCovered and linesTested to the Uberalls client

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -20,7 +20,6 @@
 
 package com.uber.jenkins.phabricator;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.uber.jenkins.phabricator.conduit.ConduitAPIClient;
 import com.uber.jenkins.phabricator.conduit.ConduitAPIException;
 import com.uber.jenkins.phabricator.conduit.Differential;
@@ -79,8 +78,6 @@ public class PhabricatorNotifier extends Notifier implements SimpleBuildStep {
     private final String lintFileSize;
     private final String coverageReportPattern;
     private transient UberallsClient uberallsClient;
-
-    @VisibleForTesting CoverageProvider testCoverageProvider;
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
@@ -319,10 +316,6 @@ public class PhabricatorNotifier extends Notifier implements SimpleBuildStep {
         }
         if (!buildResult.isBetterOrEqualTo(Result.UNSTABLE)) {
             return null;
-        }
-
-        if (testCoverageProvider != null) {
-            return testCoverageProvider;
         }
 
         Logger logger = new Logger(listener.getLogger());

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -20,6 +20,7 @@
 
 package com.uber.jenkins.phabricator;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.uber.jenkins.phabricator.conduit.ConduitAPIClient;
 import com.uber.jenkins.phabricator.conduit.ConduitAPIException;
 import com.uber.jenkins.phabricator.conduit.Differential;
@@ -78,6 +79,8 @@ public class PhabricatorNotifier extends Notifier implements SimpleBuildStep {
     private final String lintFileSize;
     private final String coverageReportPattern;
     private transient UberallsClient uberallsClient;
+
+    @VisibleForTesting CoverageProvider testCoverageProvider;
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
@@ -316,6 +319,10 @@ public class PhabricatorNotifier extends Notifier implements SimpleBuildStep {
         }
         if (!buildResult.isBetterOrEqualTo(Result.UNSTABLE)) {
             return null;
+        }
+
+        if (testCoverageProvider != null) {
+            return testCoverageProvider;
         }
 
         Logger logger = new Logger(listener.getLogger());

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
@@ -78,6 +78,8 @@ public class CoberturaCoverageProvider extends CoverageProvider {
         float methodCoverage = getCoveragePercentage(result, CoverageMetric.METHOD);
         float lineCoverage = getCoveragePercentage(result, CoverageMetric.LINE);
         float conditionalCoverage = getCoveragePercentage(result, CoverageMetric.CONDITIONAL);
+        float linesCovered = result.getCoverage(CoverageMetric.LINE).numerator;
+        float linesTested = result.getCoverage(CoverageMetric.LINE).denominator;
 
         return new CodeCoverageMetrics(
                 packagesCoverage,
@@ -85,7 +87,9 @@ public class CoberturaCoverageProvider extends CoverageProvider {
                 classesCoverage,
                 methodCoverage,
                 lineCoverage,
-                conditionalCoverage
+                conditionalCoverage,
+                linesCovered,
+                linesTested
         );
     }
 

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaCoverageProvider.java
@@ -78,8 +78,8 @@ public class CoberturaCoverageProvider extends CoverageProvider {
         float methodCoverage = getCoveragePercentage(result, CoverageMetric.METHOD);
         float lineCoverage = getCoveragePercentage(result, CoverageMetric.LINE);
         float conditionalCoverage = getCoveragePercentage(result, CoverageMetric.CONDITIONAL);
-        float linesCovered = result.getCoverage(CoverageMetric.LINE).numerator;
-        float linesTested = result.getCoverage(CoverageMetric.LINE).denominator;
+        long linesCovered = (long) result.getCoverage(CoverageMetric.LINE).numerator;
+        long linesTested = (long) result.getCoverage(CoverageMetric.LINE).denominator;
 
         return new CodeCoverageMetrics(
                 packagesCoverage,

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CodeCoverageMetrics.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CodeCoverageMetrics.java
@@ -69,9 +69,13 @@ public class CodeCoverageMetrics {
         return conditionalCoveragePercent;
     }
 
-    public float getLinesCovered() { return linesCovered; }
+    public float getLinesCovered() {
+        return linesCovered;
+    }
 
-    public float getLinesTested() { return linesTested; }
+    public float getLinesTested() {
+        return linesTested;
+    }
 
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CodeCoverageMetrics.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CodeCoverageMetrics.java
@@ -28,17 +28,21 @@ public class CodeCoverageMetrics {
     private final float methodCoveragePercent;
     private final float lineCoveragePercent;
     private final float conditionalCoveragePercent;
+    private final float linesCovered;
+    private final float linesTested;
 
     public CodeCoverageMetrics(
             float packagesCoveragePercent, float filesCoveragePercent,
             float classesCoveragePercent, float methodCoveragePercent, float lineCoveragePercent,
-            float conditionalCoveragePercent) {
+            float conditionalCoveragePercent, float linesCovered, float linesTested) {
         this.packagesCoveragePercent = packagesCoveragePercent;
         this.filesCoveragePercent = filesCoveragePercent;
         this.classesCoveragePercent = classesCoveragePercent;
         this.methodCoveragePercent = methodCoveragePercent;
         this.lineCoveragePercent = lineCoveragePercent;
         this.conditionalCoveragePercent = conditionalCoveragePercent;
+        this.linesCovered = linesCovered;
+        this.linesTested = linesTested;
     }
 
     public float getPackageCoveragePercent() {
@@ -65,6 +69,10 @@ public class CodeCoverageMetrics {
         return conditionalCoveragePercent;
     }
 
+    public float getLinesCovered() { return linesCovered; }
+
+    public float getLinesTested() { return linesTested; }
+
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("package coverage = ");
@@ -79,6 +87,10 @@ public class CodeCoverageMetrics {
         sb.append(lineCoveragePercent);
         sb.append(", conditional coverage = ");
         sb.append(conditionalCoveragePercent);
+        sb.append(", lines covered = ");
+        sb.append(linesCovered);
+        sb.append(", linesTested = ");
+        sb.append(linesTested);
         return sb.toString();
     }
 }

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CodeCoverageMetrics.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CodeCoverageMetrics.java
@@ -28,13 +28,13 @@ public class CodeCoverageMetrics {
     private final float methodCoveragePercent;
     private final float lineCoveragePercent;
     private final float conditionalCoveragePercent;
-    private final float linesCovered;
-    private final float linesTested;
+    private final long linesCovered;
+    private final long linesTested;
 
     public CodeCoverageMetrics(
             float packagesCoveragePercent, float filesCoveragePercent,
             float classesCoveragePercent, float methodCoveragePercent, float lineCoveragePercent,
-            float conditionalCoveragePercent, float linesCovered, float linesTested) {
+            float conditionalCoveragePercent, long linesCovered, long linesTested) {
         this.packagesCoveragePercent = packagesCoveragePercent;
         this.filesCoveragePercent = filesCoveragePercent;
         this.classesCoveragePercent = classesCoveragePercent;

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/JacocoCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/JacocoCoverageProvider.java
@@ -83,8 +83,8 @@ public class JacocoCoverageProvider extends CoverageProvider {
         float classCoverage = coverageResult.getClassCoverage().getPercentageFloat();
         float lineCoverage = coverageResult.getLineCoverage().getPercentageFloat();
         float branchCoverage = coverageResult.getBranchCoverage().getPercentageFloat();
-        float linesCovered = coverageResult.getLineCoverage().getCovered();
-        float linesTested = coverageResult.getLineCoverage().getTotal();
+        long linesCovered = coverageResult.getLineCoverage().getCovered();
+        long linesTested = coverageResult.getLineCoverage().getTotal();
 
         return new CodeCoverageMetrics(
                 PERCENTAGE_UNAVAILABLE,

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/JacocoCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/JacocoCoverageProvider.java
@@ -83,6 +83,8 @@ public class JacocoCoverageProvider extends CoverageProvider {
         float classCoverage = coverageResult.getClassCoverage().getPercentageFloat();
         float lineCoverage = coverageResult.getLineCoverage().getPercentageFloat();
         float branchCoverage = coverageResult.getBranchCoverage().getPercentageFloat();
+        float linesCovered = coverageResult.getLineCoverage().getCovered();
+        float linesTested = coverageResult.getLineCoverage().getTotal();
 
         return new CodeCoverageMetrics(
                 PERCENTAGE_UNAVAILABLE,
@@ -90,7 +92,9 @@ public class JacocoCoverageProvider extends CoverageProvider {
                 classCoverage,
                 methodCoverage,
                 lineCoverage,
-                branchCoverage
+                branchCoverage,
+                linesCovered,
+                linesTested
         );
     }
 

--- a/src/main/java/com/uber/jenkins/phabricator/uberalls/UberallsClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/uberalls/UberallsClient.java
@@ -113,6 +113,8 @@ public class UberallsClient {
             params.put(METHOD_COVERAGE_KEY, codeCoverageMetrics.getMethodCoveragePercent());
             params.put(LINE_COVERAGE_KEY, codeCoverageMetrics.getLineCoveragePercent());
             params.put(CONDITIONAL_COVERAGE_KEY, codeCoverageMetrics.getConditionalCoveragePercent());
+            params.put(LINES_COVERED_KEY, codeCoverageMetrics.getLinesCovered());
+            params.put(LINES_TESTED_KEY, codeCoverageMetrics.getLinesTested());
 
             try {
                 HttpClient client = getClient();

--- a/src/main/java/com/uber/jenkins/phabricator/uberalls/UberallsClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/uberalls/UberallsClient.java
@@ -92,8 +92,8 @@ public class UberallsClient {
                     ((Double) coverage.getDouble(METHOD_COVERAGE_KEY)).floatValue(),
                     ((Double) coverage.getDouble(LINE_COVERAGE_KEY)).floatValue(),
                     ((Double) coverage.getDouble(CONDITIONAL_COVERAGE_KEY)).floatValue(),
-                    ((Double) coverage.getDouble(LINES_COVERED_KEY)).floatValue(),
-                    ((Double) coverage.getDouble(LINES_TESTED_KEY)).floatValue());
+                    (coverage.getLong(LINES_COVERED_KEY)),
+                    (coverage.getLong(LINES_TESTED_KEY)));
         } catch (Exception e) {
             e.printStackTrace(logger.getStream());
         }

--- a/src/main/java/com/uber/jenkins/phabricator/uberalls/UberallsClient.java
+++ b/src/main/java/com/uber/jenkins/phabricator/uberalls/UberallsClient.java
@@ -51,6 +51,8 @@ public class UberallsClient {
     public static final String METHOD_COVERAGE_KEY = "methodCoverage";
     public static final String LINE_COVERAGE_KEY = "lineCoverage";
     public static final String CONDITIONAL_COVERAGE_KEY = "conditionalCoverage";
+    public static final String LINES_COVERED_KEY = "linesCovered";
+    public static final String LINES_TESTED_KEY = "linesTested";
 
     private static final String TAG = "uberalls-client";
 
@@ -89,7 +91,9 @@ public class UberallsClient {
                     ((Double) coverage.getDouble(CLASSES_COVERAGE_KEY)).floatValue(),
                     ((Double) coverage.getDouble(METHOD_COVERAGE_KEY)).floatValue(),
                     ((Double) coverage.getDouble(LINE_COVERAGE_KEY)).floatValue(),
-                    ((Double) coverage.getDouble(CONDITIONAL_COVERAGE_KEY)).floatValue());
+                    ((Double) coverage.getDouble(CONDITIONAL_COVERAGE_KEY)).floatValue(),
+                    ((Double) coverage.getDouble(LINES_COVERED_KEY)).floatValue(),
+                    ((Double) coverage.getDouble(LINES_TESTED_KEY)).floatValue());
         } catch (Exception e) {
             e.printStackTrace(logger.getStream());
         }

--- a/src/test/java/com/uber/jenkins/phabricator/CommentBuilderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/CommentBuilderTest.java
@@ -88,7 +88,9 @@ public class CommentBuilderTest {
                 100.0f,
                 100.0f,
                 90.0f,
-                90.0f
+                90.0f,
+                90.0f,
+                100.0f
         );
         commenter.processParentCoverage(parent, TestUtils.TEST_SHA, FAKE_BRANCH_NAME);
         String comment = commenter.getComment();
@@ -102,7 +104,7 @@ public class CommentBuilderTest {
 
     @Test
     public void testProcessWithDecreaseFailingTheBuild() {
-        CodeCoverageMetrics fiftyPercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 50.0f);
+        CodeCoverageMetrics fiftyPercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 50.0f, 50.0f, 100.0f);
         CommentBuilder commenter = createCommenter(Result.SUCCESS, fiftyPercentDrop, false, -10.0f);
         boolean passCoverage = commenter.processParentCoverage(TestUtils.getDefaultCodeCoverageMetrics(),
                 TestUtils.TEST_SHA, FAKE_BRANCH_NAME);
@@ -116,7 +118,7 @@ public class CommentBuilderTest {
 
     @Test
     public void testProcessWithDecreaseNotFailingTheBuild() {
-        CodeCoverageMetrics fivePercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 95.0f);
+        CodeCoverageMetrics fivePercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 95.0f, 95.0f, 100.0f);
         CommentBuilder commenter = createCommenter(Result.SUCCESS, fivePercentDrop, false, -10.0f);
         boolean passCoverage = commenter.processParentCoverage(TestUtils.getDefaultCodeCoverageMetrics(),
                 TestUtils.TEST_SHA, FAKE_BRANCH_NAME);
@@ -130,7 +132,7 @@ public class CommentBuilderTest {
 
     @Test
     public void testProcessWithDecreaseButHigherThanMinNotFailingTheBuild() {
-        CodeCoverageMetrics fifteenPercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 85.0f);
+        CodeCoverageMetrics fifteenPercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 85.0f, 85.0f, 100.0f);
         CommentBuilder commenter = createCommenter(Result.SUCCESS, fifteenPercentDrop, false, -10.0f, 80.0f);
         boolean passCoverage = commenter.processParentCoverage(TestUtils.getDefaultCodeCoverageMetrics(),
                 TestUtils.TEST_SHA, FAKE_BRANCH_NAME);
@@ -147,7 +149,7 @@ public class CommentBuilderTest {
         CommentBuilder commenter = new CommentBuilder(
                 logger,
                 Result.SUCCESS,
-                TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 50.0f), // 50% drop
+                TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 50.0f, 50.0f, 100.0f), // 50% drop
                 FAKE_BUILD_URL,
                 false,
                 null // coverageCheckSettings

--- a/src/test/java/com/uber/jenkins/phabricator/CommentBuilderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/CommentBuilderTest.java
@@ -89,8 +89,8 @@ public class CommentBuilderTest {
                 100.0f,
                 90.0f,
                 90.0f,
-                90.0f,
-                100.0f
+                90,
+                100
         );
         commenter.processParentCoverage(parent, TestUtils.TEST_SHA, FAKE_BRANCH_NAME);
         String comment = commenter.getComment();
@@ -104,7 +104,7 @@ public class CommentBuilderTest {
 
     @Test
     public void testProcessWithDecreaseFailingTheBuild() {
-        CodeCoverageMetrics fiftyPercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 50.0f, 50.0f, 100.0f);
+        CodeCoverageMetrics fiftyPercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 50.0f, 50, 100);
         CommentBuilder commenter = createCommenter(Result.SUCCESS, fiftyPercentDrop, false, -10.0f);
         boolean passCoverage = commenter.processParentCoverage(TestUtils.getDefaultCodeCoverageMetrics(),
                 TestUtils.TEST_SHA, FAKE_BRANCH_NAME);
@@ -118,7 +118,7 @@ public class CommentBuilderTest {
 
     @Test
     public void testProcessWithDecreaseNotFailingTheBuild() {
-        CodeCoverageMetrics fivePercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 95.0f, 95.0f, 100.0f);
+        CodeCoverageMetrics fivePercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 95.0f, 95, 100);
         CommentBuilder commenter = createCommenter(Result.SUCCESS, fivePercentDrop, false, -10.0f);
         boolean passCoverage = commenter.processParentCoverage(TestUtils.getDefaultCodeCoverageMetrics(),
                 TestUtils.TEST_SHA, FAKE_BRANCH_NAME);
@@ -132,7 +132,7 @@ public class CommentBuilderTest {
 
     @Test
     public void testProcessWithDecreaseButHigherThanMinNotFailingTheBuild() {
-        CodeCoverageMetrics fifteenPercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 85.0f, 85.0f, 100.0f);
+        CodeCoverageMetrics fifteenPercentDrop = TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 85.0f, 85, 100);
         CommentBuilder commenter = createCommenter(Result.SUCCESS, fifteenPercentDrop, false, -10.0f, 80.0f);
         boolean passCoverage = commenter.processParentCoverage(TestUtils.getDefaultCodeCoverageMetrics(),
                 TestUtils.TEST_SHA, FAKE_BRANCH_NAME);
@@ -149,7 +149,7 @@ public class CommentBuilderTest {
         CommentBuilder commenter = new CommentBuilder(
                 logger,
                 Result.SUCCESS,
-                TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 50.0f, 50.0f, 100.0f), // 50% drop
+                TestUtils.getCoverageResult(100.0f, 100.0f, 100.0f, 100.0f, 50.0f, 50, 100), // 50% drop
                 FAKE_BUILD_URL,
                 false,
                 null // coverageCheckSettings

--- a/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/PhabricatorNotifierTest.java
@@ -144,7 +144,9 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
                 "  \"packageCoverage\": 100,\n" +
                 "  \"classesCoverage\": 100,\n" +
                 "  \"methodCoverage\": 100,\n" +
-                "  \"conditionalCoverage\": 100\n" +
+                "  \"conditionalCoverage\": 100,\n" +
+                "  \"linesCovered\": 100,\n" +
+                "  \"linesTested\": 100\n" +
                 "}");
         notifier.getDescriptor().setUberallsURL("http://uber.alls");
         notifier.setUberallsClient(uberalls);
@@ -167,7 +169,9 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
                 "  \"packageCoverage\": 100,\n" +
                 "  \"classesCoverage\": 100,\n" +
                 "  \"methodCoverage\": 100,\n" +
-                "  \"conditionalCoverage\": 100\n" +
+                "  \"conditionalCoverage\": 100,\n" +
+                "  \"linesCovered\": 100,\n" +
+                "  \"linesTested\": 100\n" +
                 "}");
         notifier.getDescriptor().setUberallsURL("http://uber.alls");
         notifier.setUberallsClient(uberalls);
@@ -187,7 +191,9 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
                 "  \"packageCoverage\": 0,\n" +
                 "  \"classesCoverage\": 0,\n" +
                 "  \"methodCoverage\": 0,\n" +
-                "  \"conditionalCoverage\": 0\n" +
+                "  \"conditionalCoverage\": 100,\n" +
+                "  \"linesCovered\": 100,\n" +
+                "  \"linesTested\": 100\n" +
                 "}");
         notifier.setUberallsClient(uberalls);
 
@@ -207,7 +213,9 @@ public class PhabricatorNotifierTest extends BuildIntegrationTest {
                 "  \"packageCoverage\": 0,\n" +
                 "  \"classesCoverage\": 0,\n" +
                 "  \"methodCoverage\": 0,\n" +
-                "  \"conditionalCoverage\": 0\n" +
+                "  \"conditionalCoverage\": 100,\n" +
+                "  \"linesCovered\": 100,\n" +
+                "  \"linesTested\": 100\n" +
                 "}");
         notifier.setUberallsClient(uberalls);
 

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -154,9 +154,9 @@ public class TestUtils {
                 filesCoverage,
                 classesCoverage,
                 methodCoverage,
-                0.0f,
-                0.0f,
                 linesCoverage,
+                0.0f,
+                linesCovered,
                 linesTested
         );
     }

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -133,22 +133,22 @@ public class TestUtils {
             float methodCoveragePercent,
             float lineCoveragePercent,
             float conditionalCoveragePercent,
-            float linesCovered,
-            float linesTested) {
+            long linesCovered,
+            long linesTested) {
         return spy(new CodeCoverageMetrics(packagesCoveragePercent, filesCoveragePercent,
                 classesCoveragePercent, methodCoveragePercent, lineCoveragePercent,
                 conditionalCoveragePercent, linesCovered, linesTested));
     }
 
     public static CodeCoverageMetrics getDefaultCodeCoverageMetrics() {
-        return getCodeCoverageMetrics(100.0f, 100.0f, 100.0f, 100.0f, 100.0f, 100.0f, 100.0f, 100.0f);
+        return getCodeCoverageMetrics(100.0f, 100.0f, 100.0f, 100.0f, 100.0f, 100.0f, 100, 100);
     }
 
     public static CodeCoverageMetrics getCoverageResult(
             Float packageCoverage, Float filesCoverage,
             Float classesCoverage, Float methodCoverage,
-            Float linesCoverage, Float linesCovered,
-            Float linesTested) {
+            Float linesCoverage, long linesCovered,
+            long linesTested) {
         return new CodeCoverageMetrics(
                 packageCoverage,
                 filesCoverage,
@@ -162,7 +162,7 @@ public class TestUtils {
     }
 
     public static CodeCoverageMetrics getEmptyCoverageMetrics() {
-        return new CodeCoverageMetrics(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+        return new CodeCoverageMetrics(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0, 0);
     }
 
     public static JSONObject getJSONFromFile(Class klass, String filename) throws IOException {

--- a/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
+++ b/src/test/java/com/uber/jenkins/phabricator/utils/TestUtils.java
@@ -132,32 +132,37 @@ public class TestUtils {
             float classesCoveragePercent,
             float methodCoveragePercent,
             float lineCoveragePercent,
-            float conditionalCoveragePercent) {
+            float conditionalCoveragePercent,
+            float linesCovered,
+            float linesTested) {
         return spy(new CodeCoverageMetrics(packagesCoveragePercent, filesCoveragePercent,
                 classesCoveragePercent, methodCoveragePercent, lineCoveragePercent,
-                conditionalCoveragePercent));
+                conditionalCoveragePercent, linesCovered, linesTested));
     }
 
     public static CodeCoverageMetrics getDefaultCodeCoverageMetrics() {
-        return getCodeCoverageMetrics(100.0f, 100.0f, 100.0f, 100.0f, 100.0f, 100.0f);
+        return getCodeCoverageMetrics(100.0f, 100.0f, 100.0f, 100.0f, 100.0f, 100.0f, 100.0f, 100.0f);
     }
 
     public static CodeCoverageMetrics getCoverageResult(
             Float packageCoverage, Float filesCoverage,
             Float classesCoverage, Float methodCoverage,
-            Float linesCoverage) {
+            Float linesCoverage, Float linesCovered,
+            Float linesTested) {
         return new CodeCoverageMetrics(
                 packageCoverage,
                 filesCoverage,
                 classesCoverage,
                 methodCoverage,
+                0.0f,
+                0.0f,
                 linesCoverage,
-                0.0f
+                linesTested
         );
     }
 
     public static CodeCoverageMetrics getEmptyCoverageMetrics() {
-        return new CodeCoverageMetrics(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+        return new CodeCoverageMetrics(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
     }
 
     public static JSONObject getJSONFromFile(Class klass, String filename) throws IOException {

--- a/src/test/resources/com/uber/jenkins/phabricator/uberalls/validCoverage.json
+++ b/src/test/resources/com/uber/jenkins/phabricator/uberalls/validCoverage.json
@@ -5,5 +5,7 @@
   "packageCoverage": 100,
   "classesCoverage": 100,
   "methodCoverage": 42,
-  "conditionalCoverage": 0
+  "conditionalCoverage": 0,
+  "linesCovered": 42,
+  "linesTested": 100
 }


### PR DESCRIPTION
This is an updated PR of https://github.com/uber/phabricator-jenkins-plugin/pull/249

One comment there was to make linesCovered and linesTested an int rather than a float. I kept it a float because result.getCoverage().numerator returns a float and I would rather keep it in its original type unless people feel strongly that we should cast it.