### PR TITLE
Handle non int/long values in coverage reports

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
@@ -112,6 +112,14 @@ public class XmlCoverageProvider extends CoverageProvider {
         }
     }
 
+    private static Long getLongValue(NamedNodeMap attrs, String attr) {
+        return Math.round(Double.valueOf(attrs.getNamedItem(attr).getTextContent()));
+    }
+
+    private static Integer getIntValue(NamedNodeMap attrs, String attr) {
+        return Math.round(Float.valueOf(attrs.getNamedItem(attr).getTextContent()));
+    }
+
     private abstract static class XmlCoverageHandler {
 
         abstract boolean isApplicable(Document document);
@@ -138,10 +146,6 @@ public class XmlCoverageProvider extends CoverageProvider {
                 }
                 lineCoverage.put(entry.getKey(), sortedCounts);
             }
-        }
-
-        static int getIntValue(Node node, String attributeName) {
-            return Integer.parseInt(node.getAttributes().getNamedItem(attributeName).getTextContent());
         }
     }
 
@@ -209,8 +213,9 @@ public class XmlCoverageProvider extends CoverageProvider {
                                 continue;
                             }
 
-                            Integer lineNumber = getIntValue(line, NODE_NUMBER);
-                            hitCounts.put(lineNumber, getIntValue(line, NODE_HITS));
+                            NamedNodeMap attrs = line.getAttributes();
+                            Integer lineNumber = getIntValue(attrs, NODE_NUMBER);
+                            hitCounts.put(lineNumber, getIntValue(attrs, NODE_HITS));
                         }
                     }
                 }
@@ -222,8 +227,8 @@ public class XmlCoverageProvider extends CoverageProvider {
             NamedNodeMap attrs = root.getAttributes();
             // Branch coverage is only supported for cobertura coverage-04.dtd format
             if (attrs.getNamedItem("branches-covered") != null) {
-                long branchesCovered = Long.valueOf(attrs.getNamedItem("branches-covered").getTextContent());
-                long branchesValid = Long.valueOf(attrs.getNamedItem("branches-valid").getTextContent());
+                long branchesCovered = getLongValue(attrs, "branches-covered");
+                long branchesValid = getLongValue(attrs, "branches-valid");
                 cc.branch.covered = branchesCovered;
                 cc.branch.missed = branchesValid - branchesCovered;
             }
@@ -252,7 +257,7 @@ public class XmlCoverageProvider extends CoverageProvider {
                             if (!lineNode.getNodeName().equals("line")) {
                                 continue;
                             }
-                            int hits = Integer.valueOf(lineNode.getAttributes().getNamedItem("hits").getTextContent());
+                            int hits = getIntValue(lineNode.getAttributes(), "hits");
                             if (hits > 0) {
                                 cc.line.covered += 1;
                                 methodCovered = true;
@@ -327,10 +332,9 @@ public class XmlCoverageProvider extends CoverageProvider {
                             for (int k = 0; k < coverage.getLength(); k++) {
                                 Node coverageNode = coverage.item(k);
                                 if (coverageNode != null && "line".equals(coverageNode.getNodeName())) {
-                                    int hitCount = Integer.valueOf(
-                                            coverageNode.getAttributes().getNamedItem("ci").getTextContent());
-                                    int lineNumber = Integer.valueOf(
-                                            coverageNode.getAttributes().getNamedItem("nr").getTextContent());
+                                    NamedNodeMap attrs = coverageNode.getAttributes();
+                                    long hitCount = getIntValue(attrs, "ci");
+                                    int lineNumber = getIntValue(attrs, "nr");
                                     hitCounts.put(lineNumber, hitCount > 0 ? 1 : 0);
                                 }
                             }

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
@@ -113,11 +113,21 @@ public class XmlCoverageProvider extends CoverageProvider {
     }
 
     private static Long getLongValue(NamedNodeMap attrs, String attr) {
-        return Math.round(Double.valueOf(attrs.getNamedItem(attr).getTextContent()));
+        String content = attrs.getNamedItem(attr).getTextContent();
+        try {
+            return Math.round(Double.valueOf(content));
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException(content + " is not a valid coverage number", e);
+        }
     }
 
     private static Integer getIntValue(NamedNodeMap attrs, String attr) {
-        return Math.round(Float.valueOf(attrs.getNamedItem(attr).getTextContent()));
+        String content = attrs.getNamedItem(attr).getTextContent();
+        try {
+            return Math.round(Float.valueOf(content));
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException(content + " is not a valid coverage number", e);
+        }
     }
 
     private abstract static class XmlCoverageHandler {

--- a/src/test/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProviderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProviderTest.java
@@ -30,6 +30,7 @@ public class XmlCoverageProviderTest {
     private static final String TEST_COVERAGE_FILE_2 = "go-torch-coverage2.xml";
     private static final String TEST_COVERAGE_FILE_3 = "go-torch-coverage3.xml";
     private static final String TEST_COVERAGE_FILE_MULTIPLE_INCLUDE = "multiple-include-coverage.xml";
+    private static final String TEST_COVERAGE_FILE_INVALID = "invalid-coverage.xml";
 
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();
@@ -113,6 +114,12 @@ public class XmlCoverageProviderTest {
         assertEquals(1, greetBCoverage.get(6).longValue());
         assertNull(eetCoverage);
         assertNull(partialMatchCoverage);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidCoverage() {
+        CoverageProvider provider = new XmlCoverageProvider(getResources(TEST_COVERAGE_FILE_INVALID));
+        provider.getLineCoverage();
     }
 
     private Set<File> getResources(String... resources) {

--- a/src/test/resources/com/uber/jenkins/phabricator/coverage/invalid-coverage.xml
+++ b/src/test/resources/com/uber/jenkins/phabricator/coverage/invalid-coverage.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<coverage line-rate="foo" branch-rate="" lines-covered="" lines-valid=""
+		  branches-covered="" branches-valid="bar">
+	<packages/>
+</coverage>

--- a/src/test/resources/com/uber/jenkins/phabricator/coverage/multiple-include-coverage.xml
+++ b/src/test/resources/com/uber/jenkins/phabricator/coverage/multiple-include-coverage.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
-<coverage line-rate="0.005225342913128674" branch-rate="0.003992015968063872" lines-covered="8" lines-valid="1531" branches-covered="2" branches-valid="501" complexity="2.1768488745980705" version="2.1.1" timestamp="1537982333809">
+<coverage line-rate="0.005225342913128674" branch-rate="0.003992015968063872" lines-covered="8" lines-valid="1531"
+		  branches-covered="2.0" branches-valid="501.0" complexity="2.1768488745980705" version="2.1.1"
+		  timestamp="1537982333809">
 	<packages>
 				<package name="com.uber.jenkins.phabricator.packageA" line-rate="0.8" branch-rate="0.5" complexity="2.0">
 			<classes>


### PR DESCRIPTION
Some tools output coverage numbers like "1.0" instead of "1". This behavior is not usual, but the plugin should be able to handle those