### PR TITLE
Add support for Clover coverage xml reports

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
@@ -185,7 +185,7 @@ public class XmlCoverageProvider extends CoverageProvider {
         @Override
         boolean isApplicable(Document document) {
             Element documentElement = document.getDocumentElement();
-            if(!documentElement.getTagName().equals("coverage")) {
+            if (!documentElement.getTagName().equals("coverage")) {
                 return false;
             }
 
@@ -408,7 +408,7 @@ public class XmlCoverageProvider extends CoverageProvider {
         @Override
         boolean isApplicable(Document document) {
             Element documentElement = document.getDocumentElement();
-            if(!documentElement.getTagName().equals("coverage")) {
+            if (!documentElement.getTagName().equals("coverage")) {
                 return false;
             }
 
@@ -436,7 +436,7 @@ public class XmlCoverageProvider extends CoverageProvider {
                 NodeList fileNodes = packageNode.getChildNodes();
                 for (int j = 0; j < fileNodes.getLength(); j++) {
                     Node fileNode = fileNodes.item(j);
-                    if(!fileNode.hasAttributes()) {
+                    if (!fileNode.hasAttributes()) {
                         continue;
                     }
 
@@ -467,9 +467,9 @@ public class XmlCoverageProvider extends CoverageProvider {
                 Node packageNode = packages.item(i);
                 NodeList packageChildren = packageNode.getChildNodes();
                 boolean packageCovered = false;
-                for( int j = 0; j < packageChildren.getLength(); j++) {
+                for (int j = 0; j < packageChildren.getLength(); j++) {
                     Node fileNode = packageChildren.item(j);
-                    if(!fileNode.getNodeName().equals("file")) {
+                    if (!fileNode.getNodeName().equals("file")) {
                         continue;
                     }
 
@@ -482,7 +482,7 @@ public class XmlCoverageProvider extends CoverageProvider {
                             Node lineChild = fileChild;
                             NamedNodeMap lineAttributes = lineChild.getAttributes();
                             String typeAttributeText = lineAttributes.getNamedItem("type").getTextContent();
-                            if(typeAttributeText.equals("stmt")) {
+                            if (typeAttributeText.equals("stmt")) {
                                 int lineHits = getIntValue(lineAttributes, "count");
                                 if (lineHits > 0) {
                                     fileCovered = true;
@@ -490,7 +490,7 @@ public class XmlCoverageProvider extends CoverageProvider {
                                 } else {
                                     cc.line.missed += 1;
                                 }
-                            } else if(typeAttributeText.equals("method")) {
+                            } else if (typeAttributeText.equals("method")) {
                                 int methodHits = getIntValue(lineAttributes, "count");
                                 if (methodHits > 0) {
                                     fileCovered = true;
@@ -504,11 +504,11 @@ public class XmlCoverageProvider extends CoverageProvider {
                         if (fileChild.getNodeName().equals("class")) {
                             Node classNode = fileChild;
                             NodeList classChildren = classNode.getChildNodes();
-                            for( int l = 0; l < classChildren.getLength(); l++ ) {
+                            for (int l = 0; l < classChildren.getLength(); l++) {
                                 Node metricNode = classChildren.item(l);
-                                if(metricNode.getNodeName().equals("metrics")) {
+                                if (metricNode.getNodeName().equals("metrics")) {
                                     Integer coveredstatements = getIntValue(metricNode.getAttributes(), "coveredstatements");
-                                    if(coveredstatements > 0) {
+                                    if (coveredstatements > 0) {
                                         fileCovered = true;
                                         cc.cls.covered += 1;
                                     } else {
@@ -518,7 +518,7 @@ public class XmlCoverageProvider extends CoverageProvider {
                             }
                         }
                     }
-                    if(fileCovered) {
+                    if (fileCovered) {
                         packageCovered = true;
                         cc.file.covered += 1;
                     } else {
@@ -544,7 +544,7 @@ public class XmlCoverageProvider extends CoverageProvider {
                 return coverageFile;
             } else {
                 for (String includedFile : includeFiles) {
-                    if(coverageFile.contains(includedFile)) {
+                    if (coverageFile.contains(includedFile)) {
                         return includedFile;
                     }
                 }

--- a/src/test/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProviderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProviderTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -62,6 +63,34 @@ public class XmlCoverageProviderTest {
         assertEquals(0, coverage.get("com/uber/nullaway/jarinfer/StubxWriter.java").get(73).longValue());
         assertEquals(new CodeCoverageMetrics(100.0f, 100.0f, 100.f, 92.59259f, 90.10989f, 69.09091f, 328, 364),
                 provider.getMetrics());
+    }
+
+    @Test
+    public void cloverPhpunit() {
+        CoverageProvider provider = new XmlCoverageProvider(getResources("clover-phpunit-coverage.xml"));
+
+        assertTrue(provider.hasCoverage());
+
+        Map<String, List<Integer>> lineCoverage = provider.getLineCoverage();
+        String expectedKey = "/home/ubuntu/example-php/src/Example/Example.php";
+
+        assertNull(lineCoverage.get(expectedKey).get(4));
+        assertEquals(1, lineCoverage.get(expectedKey).get(6).longValue());
+        assertEquals(0, lineCoverage.get(expectedKey).get(7).longValue());
+        assertEquals(1, lineCoverage.get(expectedKey).get(10).longValue());
+        assertEquals(new CodeCoverageMetrics(100.0f, 100.0f, 100.f, 100.0f, 66.66667f, 100.0f, 2, 3),
+                provider.getMetrics());
+    }
+
+    @Test public void cloverWithIncludeFiles() {
+        CoverageProvider provider = new XmlCoverageProvider(getResources("clover-phpunit-coverage.xml"),
+                Collections.singleton("src/Example/Example.php"));
+
+        assertTrue(provider.hasCoverage());
+
+        Map<String, List<Integer>> lineCoverage = provider.getLineCoverage();
+        List<Integer> exampleCoverage = lineCoverage.get("src/Example/Example.php");
+        assertNotNull(exampleCoverage);
     }
 
     @Test

--- a/src/test/resources/com/uber/jenkins/phabricator/coverage/clover-phpunit-coverage.xml
+++ b/src/test/resources/com/uber/jenkins/phabricator/coverage/clover-phpunit-coverage.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage generated="1542744031">
+  <project timestamp="1542744031">
+    <package name="Example">
+      <file name="/home/ubuntu/example-php/src/Example/Example.php">
+        <class name="Example" namespace="Example">
+          <metrics methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="4" coveredelements="2"/>
+        </class>
+        <line num="5" type="method" name="go" crap="2.15" count="1"/>
+        <line num="7" type="stmt" count="1"/>
+        <line num="8" type="stmt" count="0"/>
+        <line num="11" type="stmt" count="1"/>
+        <metrics loc="14" ncloc="14" classes="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="4" coveredelements="2"/>
+      </file>
+    </package>
+    <metrics files="1" loc="14" ncloc="14" classes="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="4" coveredelements="2"/>
+  </project>
+</coverage>


### PR DESCRIPTION
Should fix #142.

Adds a new CloverXmlCoverageHandler for Clover coverage reports.

I've used a simple coverage file created with this example php project: https://github.com/codecov/example-php. So this is only tested with a Clover report created with phpunit, which currently doesn't validate against the clover.xsd: https://github.com/sebastianbergmann/php-code-coverage/issues/578


