### PR TITLE
Add Mercurial support

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapper.java
@@ -59,11 +59,13 @@ import hudson.util.RunList;
 public class PhabricatorBuildWrapper extends BuildWrapper {
 
     private static final String CONDUIT_TAG = "conduit";
-    private static final String DEFAULT_GIT_PATH = "git";
     private static final String DIFFERENTIAL_SUMMARY = "PHABRICATOR_DIFFERENTIAL_SUMMARY";
     private static final String DIFFERENTIAL_AUTHOR = "PHABRICATOR_DIFFERENTIAL_AUTHOR";
     private static final String DIFFERENTIAL_BASE_COMMIT = "PHABRICATOR_DIFFERENTIAL_BASE_COMMIT";
     private static final String DIFFERENTIAL_BRANCH = "PHABRICATOR_DIFFERENTIAL_BRANCH";
+
+    private static final String DEFAULT_GIT_BRANCH = "origin/master";
+    private static final String DEFAULT_HG_BRANCH = "default";
 
     private final boolean createCommit;
     private final boolean applyToMaster;
@@ -190,7 +192,12 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
         if (skipApplyPatch) {
             logger.info("arcanist", "Skipping applying arc patch as configured in job");
         } else {
-            String baseCommit = "origin/master";
+
+            String baseCommit = DEFAULT_GIT_BRANCH;
+            if ("hg".equals(scmType)) {
+                baseCommit = DEFAULT_HG_BRANCH;
+            }
+
             if (!applyToMaster) {
                 baseCommit = diff.getBaseCommit();
             }
@@ -199,9 +206,8 @@ public class PhabricatorBuildWrapper extends BuildWrapper {
             final String conduitUrl = this.getPhabricatorURL(build.getParent());
             Task.Result result = new ApplyPatchTask(
                     logger, starter, baseCommit, diffID, conduitUrl, conduitToken, getArcPath(),
-                    DEFAULT_GIT_PATH, createCommit, skipForcedClean, createBranch,
-                    patchWithForceFlag, scmType
-            ).run();
+                    createCommit, skipForcedClean, createBranch,
+                    patchWithForceFlag, scmType).run();
 
             if (result != Task.Result.SUCCESS) {
                 logger.warn("arcanist", "Error applying arc patch; got non-zero exit code " + result);

--- a/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
+++ b/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
@@ -20,6 +20,7 @@
 
 package com.uber.jenkins.phabricator.tasks;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.uber.jenkins.phabricator.LauncherFactory;
 import com.uber.jenkins.phabricator.conduit.ArcanistClient;
 import com.uber.jenkins.phabricator.utils.Logger;
@@ -87,6 +88,7 @@ public class ApplyPatchTask extends Task {
     /**
      * Allows to override default exeturable path used for git
      */
+    @VisibleForTesting
     void setGitPath(String gitPath) {
         this.gitPath = gitPath;
     }
@@ -94,6 +96,7 @@ public class ApplyPatchTask extends Task {
     /**
      * Allows to override default exeturable path used for git
      */
+    @VisibleForTesting
     void setHgPath(String hgPath) {
         this.hgPath = hgPath;
     }
@@ -164,7 +167,6 @@ public class ApplyPatchTask extends Task {
         return exitCode;
     }
 
-    @SuppressWarnings("UnusedReturnValue")
     private void prepareRepositoryState() throws InterruptedException, IOException {
         List<String> resetToBaseCommit = Collections.emptyList();
         List<String> cleanWorkingDir = Collections.emptyList();

--- a/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
+++ b/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
@@ -86,7 +86,7 @@ public class ApplyPatchTask extends Task {
     }
 
     /**
-     * Allows to override default exeturable path used for git
+     * Allows to override default executable path used for git
      */
     @VisibleForTesting
     void setGitPath(String gitPath) {
@@ -94,7 +94,7 @@ public class ApplyPatchTask extends Task {
     }
 
     /**
-     * Allows to override default exeturable path used for git
+     * Allows to override default executable path used for git
      */
     @VisibleForTesting
     void setHgPath(String hgPath) {

--- a/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
+++ b/src/main/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTask.java
@@ -28,45 +28,74 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class ApplyPatchTask extends Task {
+    private static final String DEFAULT_GIT_PATH = "git";
+    private static final String DEFAULT_HG_PATH = "hg";
 
     private final LauncherFactory starter;
-    private final String baseCommit;
-    private final String diffID;
     private final PrintStream logStream;
+
+    private final String scmType;
+
+    private String gitPath;
+    private String hgPath;
+    private final String arcPath;
+
+    private final boolean skipForcedClean;
+
+    private final String baseCommit;
+
     private final String conduitUrl;
     private final String conduitToken;
-    private final String arcPath;
+
+    private final String diffID;
     private final boolean createCommit;
-    private final String gitPath;
-    private final boolean skipForcedClean;
     private final boolean createBranch;
     private final boolean patchWithForceFlag;
-    private final String scmType;
 
     public ApplyPatchTask(
             Logger logger, LauncherFactory starter, String baseCommit,
-            String diffID, String conduitUrl, String conduitToken,
-            String arcPath, String gitPath, boolean createCommit,
+            String diffID, String conduitUrl, String conduitToken, String arcPath,
+            boolean createCommit,
             boolean skipForcedClean, boolean createBranch,
             boolean patchWithForceFlag, String scmType) {
         super(logger);
+
+        this.arcPath = arcPath;
+        this.gitPath = DEFAULT_GIT_PATH;
+        this.hgPath = DEFAULT_HG_PATH;
+
+        this.scmType = scmType;
+
         this.starter = starter;
+        this.logStream = logger.getStream();
+
         this.baseCommit = baseCommit;
         this.diffID = diffID;
         this.conduitUrl = conduitUrl;
         this.conduitToken = conduitToken;
-        this.arcPath = arcPath;
-        this.gitPath = gitPath;
+
         this.createCommit = createCommit;
         this.skipForcedClean = skipForcedClean;
         this.createBranch = createBranch;
         this.patchWithForceFlag = patchWithForceFlag;
-        this.scmType = scmType;
+    }
 
-        this.logStream = logger.getStream();
+    /**
+     * Allows to override default exeturable path used for git
+     */
+    void setGitPath(String gitPath) {
+        this.gitPath = gitPath;
+    }
+
+    /**
+     * Allows to override default exeturable path used for git
+     */
+    void setHgPath(String hgPath) {
+        this.hgPath = hgPath;
     }
 
     /**
@@ -91,35 +120,21 @@ public class ApplyPatchTask extends Task {
     @Override
     protected void execute() {
         try {
-            int exitCode;
-            if (this.scmType.equals("git")) {
-                exitCode = starter.launch()
-                        .cmds(Arrays.asList(gitPath, "reset", "--hard", baseCommit))
-                        .stdout(logStream)
-                        .join();
+            prepareRepositoryState();
+            this.result = applyArcPatch() == 0 ? Result.SUCCESS : Result.FAILURE;
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace(logStream);
+            this.result = Result.FAILURE;
+        }
+    }
 
-                if (exitCode != 0) {
-                    info("Got non-zero exit code resetting to base commit " + baseCommit + ": " + exitCode);
-                }
+    private int applyArcPatch() throws IOException, InterruptedException {
+        int exitCode;
+        List<String> arcPatchParams = new ArrayList<String>(Arrays.asList("--diff", diffID));
 
-                if (!skipForcedClean) {
-                    // Clean workspace, otherwise `arc patch` may fail
-                    starter.launch()
-                            .stdout(logStream)
-                            .cmds(Arrays.asList(gitPath, "clean", "-fd", "-f"))
-                            .join();
-                }
-
-                // Update submodules recursively.
-                starter.launch()
-                        .stdout(logStream)
-                        .cmds(Arrays.asList(gitPath, "submodule", "update", "--init", "--recursive"))
-                        .join();
-            }
-
-            List<String> arcPatchParams = new ArrayList<String>(Arrays.asList("--diff", diffID));
-
-            if (this.scmType.equals("git")) {
+        switch (scmType) {
+            case "git":
+            case "hg":
                 if (!createCommit) {
                     arcPatchParams.add("--nocommit");
                 }
@@ -127,28 +142,72 @@ public class ApplyPatchTask extends Task {
                 if (!createBranch) {
                     arcPatchParams.add("--nobranch");
                 }
-            }
-
-            if (patchWithForceFlag) {
-                arcPatchParams.add("--force");
-            }
-
-            ArcanistClient arc = new ArcanistClient(
-                    arcPath,
-                    "patch",
-                    conduitUrl,
-                    conduitToken,
-                    arcPatchParams.toArray(new String[arcPatchParams.size()]));
-
-            exitCode = arc.callConduit(starter.launch(), logStream);
-            this.result = exitCode == 0 ? Result.SUCCESS : Result.FAILURE;
-        } catch (IOException e) {
-            e.printStackTrace(logStream);
-            this.result = Result.FAILURE;
-        } catch (InterruptedException e) {
-            e.printStackTrace(logStream);
-            this.result = Result.FAILURE;
+                break;
+            case "svn":
+                break;
+            default:
+                info("Unknown scm type " + scmType + " skipping");
         }
+
+        if (patchWithForceFlag) {
+            arcPatchParams.add("--force");
+        }
+
+        ArcanistClient arc = new ArcanistClient(
+                arcPath,
+                "patch",
+                conduitUrl,
+                conduitToken,
+                arcPatchParams.toArray(new String[arcPatchParams.size()]));
+
+        exitCode = arc.callConduit(starter.launch(), logStream);
+        return exitCode;
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    private void prepareRepositoryState() throws InterruptedException, IOException {
+        List<String> resetToBaseCommit = Collections.emptyList();
+        List<String> cleanWorkingDir = Collections.emptyList();
+        List<String> updateSubmodules = Collections.emptyList();
+
+        switch (scmType) {
+            case "git":
+                resetToBaseCommit = Arrays.asList(gitPath, "reset", "--hard", baseCommit);
+                cleanWorkingDir = Arrays.asList(gitPath, "clean", "-fd", "-f");
+                updateSubmodules = Arrays.asList(gitPath, "submodule", "update", "--init", "--recursive");
+                break;
+            case "hg":
+                resetToBaseCommit = Arrays.asList(hgPath, "update", "--clean", baseCommit);
+                // Purge is core extension but not enabled by default
+                cleanWorkingDir = Arrays.asList(hgPath, "--config", "extensions.purge=", "purge", "--files", "--dirs");
+                // Submodules updated by resetToBaseCommit command
+                updateSubmodules = Collections.emptyList();
+                break;
+            case "svn":
+                break;
+            default:
+                info("Unknown scm type " + scmType + " skipping");
+                return;
+        }
+
+        int exitCode = launch(resetToBaseCommit);
+
+        if (exitCode != 0) {
+            info("Got non-zero exit code resetting to base commit " + baseCommit + ": " + exitCode);
+        }
+
+        if (!skipForcedClean) {
+            launch(cleanWorkingDir);
+        }
+
+        launch(updateSubmodules);
+    }
+
+    private int launch(List<String> cmds) throws IOException, InterruptedException {
+        if (cmds.isEmpty()) {
+            return 0;
+        }
+        return starter.launch().cmds(cmds).stdout(logStream).join();
     }
 
     /**

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/config.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/config.jelly
@@ -2,22 +2,23 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="SCM type" field="scmType" description="SCM used in this job">
           <f:radio name="scmType" title="git" value="git" checked="${instance.scmType == 'git' || instance.scmType == null}" />
+          <f:radio name="scmType" title="hg" value="hg" checked="${instance.scmType == 'hg'}" />
           <f:radio name="scmType" title="svn" value="svn" checked="${instance.scmType == 'svn'}" />
   </f:entry>
-  <f:entry title="Create git commit" field="createCommit"
-           description="Create a git commit with the patch">
+  <f:entry title="Create commit" field="createCommit"
+           description="Create a commit with the patch. Supports: git, hg">
       <f:checkbox />
   </f:entry>
   <f:entry title="Apply patch to master" field="applyToMaster"
            description="If true, always arc patch apply to master">
       <f:checkbox />
   </f:entry>
-  <f:entry title="Skip Forced Git clean" field="skipForcedClean"
-           description="Skip 'git clean -fd -f' step.">
+  <f:entry title="Skip forced clean" field="skipForcedClean"
+           description="Skip repository clean step. Git: 'git clean -fd -f', hg: 'hg purge --dirs --files'">
       <f:checkbox default="false" />
   </f:entry>
-  <f:entry title="Create git branch" field="createBranch"
-           description="Create a git branch with the patch">
+  <f:entry title="Create branch" field="createBranch"
+           description="Create a branch with the patch. Supports: git, hg">
       <f:checkbox />
   </f:entry>
   <f:entry title="Run 'arc patch' with '--force'" field="patchWithForceFlag"

--- a/src/test/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTaskTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/tasks/ApplyPatchTaskTest.java
@@ -35,40 +35,55 @@ public class ApplyPatchTaskTest {
 
     @Test
     public void testApplyPatchWithValidArc() throws Exception {
-        ApplyPatchTask task = getTask("echo", "true");
-        Task.Result result = task.run();
+        ApplyPatchTask task;
+        Task.Result result;
+
+        task = getTask("echo", "git", "true");
+        result = task.run();
+        assertEquals(Task.Result.SUCCESS, result);
+
+        task = getTask("echo", "hg", "true");
+        result = task.run();
         assertEquals(Task.Result.SUCCESS, result);
     }
 
     @Test
     public void testApplyPatchForSvnWithValidArc() throws Exception {
-        ApplyPatchTask task = new ApplyPatchTask(
-                TestUtils.getDefaultLogger(),
-                TestUtils.createLauncherFactory(j),
-                TestUtils.TEST_SHA,
-                TestUtils.TEST_DIFFERENTIAL_ID,
-                TestUtils.TEST_CONDUIT_URL,
-                TestUtils.TEST_CONDUIT_TOKEN,
-                "echo", "true", false, false, false, false, "svn");
+        ApplyPatchTask task = getTask("echo", "svn", "true");
         Task.Result result = task.run();
         assertEquals(Task.Result.SUCCESS, result);
     }
 
     @Test
     public void testApplyPatchWithInvalidArc() throws Exception {
-        ApplyPatchTask task = getTask("false", "echo");
-        Task.Result result = task.run();
+        ApplyPatchTask task;
+        Task.Result result;
+
+        task = getTask("false", "git", "echo");
+        result = task.run();
+        assertEquals(Task.Result.FAILURE, result);
+
+        task = getTask("false", "hg", "echo");
+        result = task.run();
         assertEquals(Task.Result.FAILURE, result);
     }
 
     @Test
     public void testBothGitAndArcFailing() throws Exception {
-        ApplyPatchTask task = getTask("false", "false");
-        assertEquals(Task.Result.FAILURE, task.run());
+        ApplyPatchTask task;
+        Task.Result result;
+
+        task = getTask("false", "git", "false");
+        result = task.run();
+        assertEquals(Task.Result.FAILURE, result);
+
+        task = getTask("false", "hg", "false");
+        result = task.run();
+        assertEquals(Task.Result.FAILURE, result);
     }
 
-    private ApplyPatchTask getTask(String arcPath, String gitPath) throws Exception {
-        return new ApplyPatchTask(
+    private ApplyPatchTask getTask(String arcPath, String scmType, String scmPath) throws Exception {
+        final ApplyPatchTask task = new ApplyPatchTask(
                 TestUtils.getDefaultLogger(),
                 TestUtils.createLauncherFactory(j),
                 TestUtils.TEST_SHA,
@@ -76,12 +91,24 @@ public class ApplyPatchTaskTest {
                 TestUtils.TEST_CONDUIT_URL,
                 TestUtils.TEST_CONDUIT_TOKEN,
                 arcPath,
-                gitPath, // git path
                 false, // createCommit
                 false, // skipForcedClean
                 false, // createBranch
                 false,  // patchWithForceFlag
-                "git" // scmType
+                scmType
         );
+        switch (scmType) {
+            case "git":
+                task.setGitPath(scmPath);
+                break;
+            case "hg":
+                task.setHgPath(scmPath);
+                break;
+            case "svn":
+            default:
+                break; // do nothing
+        }
+
+        return task;
     }
 }


### PR DESCRIPTION
 - Split `ApplyPatchTask#execute` in two phases: `prepareRepository` and `applyPatch`
 - Leave prepareRepository flow unchanged, i.e. if some command fails task excution
   continues
 - Remove `DEFAULT_GIT_PATH` from `ApplyPatchTask` constructor. Add separate methods
   `ApplyPatchTask#setGitPath()` and `ApplyPatchTask#setHgPath()`. This methods
   expected to be used in test fixtures only.
 - Update 'master branch' selection to support hg default branch name
 - Update jelly template for `PhabricatorBuildWrapper` to support hg settings.