### PR TITLE
Fix cobertura line coverage metric and use unique name for copied coverage reports

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -72,6 +72,7 @@ public class PhabricatorNotifier extends Notifier implements SimpleBuildStep {
     private static final String UBERALLS_TAG = "uberalls";
     private static final String COVERAGE_TAG = "coverage";
     private static final String CONDUIT_TAG = "conduit";
+    private static final String PHABRICATOR_COVERAGE = "phabricator-coverage";
     // Post a comment on success. Useful for lengthy builds.
     private final boolean commentOnSuccess;
     private final boolean uberallsEnabled;
@@ -354,7 +355,7 @@ public class PhabricatorNotifier extends Notifier implements SimpleBuildStep {
             try {
                 int i = 0;
                 for (FilePath report : moduleRoot.list(finalCoverageReportPattern)) {
-                    final FilePath targetPath = new FilePath(buildTarget, "coverage" + (i == 0 ? "" : i) + ".xml");
+                    final FilePath targetPath = new FilePath(buildTarget, PHABRICATOR_COVERAGE + (i == 0 ? "" : i) + ".xml");
                     report.copyTo(targetPath);
                     i++;
                 }
@@ -484,7 +485,7 @@ public class PhabricatorNotifier extends Notifier implements SimpleBuildStep {
 
         @Override
         public boolean accept(File dir, String name) {
-            return name.startsWith("coverage") && name.endsWith("xml");
+            return name.startsWith(PHABRICATOR_COVERAGE) && name.endsWith("xml");
         }
     }
 }

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
@@ -225,7 +225,14 @@ public class XmlCoverageProvider extends CoverageProvider {
 
                             NamedNodeMap attrs = line.getAttributes();
                             Integer lineNumber = getIntValue(attrs, NODE_NUMBER);
-                            hitCounts.put(lineNumber, getIntValue(attrs, NODE_HITS));
+                            int hits = getIntValue(attrs, NODE_HITS);
+                            hitCounts.put(lineNumber, hits);
+
+                            if (hits > 0) {
+                                cc.line.covered += 1;
+                            } else {
+                                cc.line.missed += 1;
+                            }
                         }
                     }
                 }
@@ -253,6 +260,7 @@ public class XmlCoverageProvider extends CoverageProvider {
                     if (!classNode.getNodeName().equals("class")) {
                         continue;
                     }
+
                     NodeList methods = getChildrenWithMatchingTag(classNode, "methods");
                     boolean classCovered = false;
                     for (int k = 0; k < methods.getLength(); k++) {
@@ -269,10 +277,8 @@ public class XmlCoverageProvider extends CoverageProvider {
                             }
                             int hits = getIntValue(lineNode.getAttributes(), "hits");
                             if (hits > 0) {
-                                cc.line.covered += 1;
                                 methodCovered = true;
-                            } else {
-                                cc.line.missed += 1;
+                                break;
                             }
                         }
                         if (methodCovered) {


### PR DESCRIPTION
- Cobertura coverage metric was not counting all the lines properly before. Verified against existing reports where coverage was reported incorrectly before and ensured it is fixed now
- Use unique name for phabricator jenkins plugin coverage reports to stop interfering with the coverage xml files on master used by the cobertura jenkins plugin