### PR TITLE
Revert back to relying on coverage plugin results if they exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
   jenkinsPlugins 'org.jenkins-ci.plugins:credentials:1.22@jar'
 
   optionalJenkinsPlugins 'org.jenkins-ci.plugins:junit:1.6@jar'
+  optionalJenkinsPlugins 'org.jenkins-ci.plugins:cobertura:1.11@jar'
+  optionalJenkinsPlugins 'org.jenkins-ci.plugins:jacoco:2.2.1@jar'
   providedCompile 'org.jacoco:org.jacoco.report:0.7.8'
 
   testCompile 'junit:junit:4.12'

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaPluginCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/CoberturaPluginCoverageProvider.java
@@ -1,0 +1,93 @@
+// Copyright (c) 2018 Uber
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package com.uber.jenkins.phabricator.coverage;
+
+import java.io.File;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.plugins.cobertura.CoberturaBuildAction;
+import hudson.plugins.cobertura.Ratio;
+import hudson.plugins.cobertura.targets.CoverageMetric;
+import hudson.plugins.cobertura.targets.CoverageResult;
+
+/**
+ * Provide Cobertura coverage data via the Jenkins Cobertura Plugin
+ */
+public class CoberturaPluginCoverageProvider extends XmlCoverageProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(CoberturaPluginCoverageProvider.class.getName());
+
+    private final CoberturaBuildAction buildAction;
+
+    public CoberturaPluginCoverageProvider(Set<File> coverageReports, Set<String> includeFiles, CoberturaBuildAction buildAction) {
+        super(coverageReports, includeFiles);
+        this.buildAction = buildAction;
+    }
+
+    @Override
+    protected void computeMetrics() {
+        CoverageResult coverageResult = buildAction.getResult();
+        metrics = convertCobertura(coverageResult);
+    }
+
+    /**
+     * Convert Cobertura results to an internal CodeCoverageMetrics representation
+     *
+     * @param result The cobertura report
+     * @return The internal representation of coverage
+     */
+    @VisibleForTesting
+     static CodeCoverageMetrics convertCobertura(CoverageResult result) {
+        if (result == null) {
+            return null;
+        }
+
+        float packagesCoverage = getCoveragePercentage(result, CoverageMetric.PACKAGES);
+        float filesCoverage = getCoveragePercentage(result, CoverageMetric.FILES);
+        float classesCoverage = getCoveragePercentage(result, CoverageMetric.CLASSES);
+        float methodCoverage = getCoveragePercentage(result, CoverageMetric.METHOD);
+        float lineCoverage = getCoveragePercentage(result, CoverageMetric.LINE);
+        float conditionalCoverage = getCoveragePercentage(result, CoverageMetric.CONDITIONAL);
+        long linesCovered = (long) result.getCoverage(CoverageMetric.LINE).numerator;
+        long linesTested = (long) result.getCoverage(CoverageMetric.LINE).denominator;
+
+        return new CodeCoverageMetrics(
+                packagesCoverage,
+                filesCoverage,
+                classesCoverage,
+                methodCoverage,
+                lineCoverage,
+                conditionalCoverage,
+                linesCovered,
+                linesTested
+        );
+    }
+
+    private static float getCoveragePercentage(CoverageResult result, CoverageMetric metric) {
+        Ratio ratio = result.getCoverage(metric);
+        if (ratio == null) {
+            return 0.0f;
+        }
+        return ratio.getPercentageFloat();
+    }
+}

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/JacocoPluginCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/JacocoPluginCoverageProvider.java
@@ -1,0 +1,79 @@
+// Copyright (c) 2018 Uber
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package com.uber.jenkins.phabricator.coverage;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.plugins.jacoco.JacocoBuildAction;
+import hudson.plugins.jacoco.report.CoverageReport;
+
+import java.io.File;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Provide Jacoco coverage data via the Jenkins Jacoco Plugin
+ */
+public class JacocoPluginCoverageProvider extends XmlCoverageProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(JacocoPluginCoverageProvider.class.getName());
+
+    private final JacocoBuildAction buildAction;
+
+    public JacocoPluginCoverageProvider(Set<File> coverageReports, Set<String> includeFiles, JacocoBuildAction buildAction) {
+        super(coverageReports, includeFiles);
+        this.buildAction = buildAction;
+    }
+
+    @Override
+    protected void computeMetrics() {
+        CoverageReport coverageResult = buildAction.getResult();
+        metrics = convertJacoco(coverageResult);
+    }
+
+    /**
+     * Convert Jacoco results to an internal CodeCoverageMetrics representation
+     *
+     * @param coverageResult The jacoco report
+     * @return The internal representation of coverage
+     */
+    @VisibleForTesting
+    static CodeCoverageMetrics convertJacoco(CoverageReport coverageResult) {
+        if (coverageResult == null) {
+            return null;
+        }
+        float methodCoverage = coverageResult.getMethodCoverage().getPercentageFloat();
+        float classCoverage = coverageResult.getClassCoverage().getPercentageFloat();
+        float lineCoverage = coverageResult.getLineCoverage().getPercentageFloat();
+        float branchCoverage = coverageResult.getBranchCoverage().getPercentageFloat();
+        long linesCovered = coverageResult.getLineCoverage().getCovered();
+        long linesTested = coverageResult.getLineCoverage().getTotal();
+        return new CodeCoverageMetrics(
+                -1,
+                -1,
+                classCoverage,
+                methodCoverage,
+                lineCoverage,
+                branchCoverage,
+                linesCovered,
+                linesTested
+        );
+    }
+}

--- a/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
+++ b/src/main/java/com/uber/jenkins/phabricator/coverage/XmlCoverageProvider.java
@@ -84,6 +84,10 @@ public class XmlCoverageProvider extends CoverageProvider {
         } catch (SAXException | IOException e) {
             e.printStackTrace();
         }
+        computeMetrics();
+    }
+
+    protected void computeMetrics() {
         // Aggregate coverage metrics
         metrics = new CodeCoverageMetrics(
                 cc.pkg.getPercent(),

--- a/src/test/java/com/uber/jenkins/phabricator/coverage/CoberturaPluginCoverageProviderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/coverage/CoberturaPluginCoverageProviderTest.java
@@ -1,0 +1,28 @@
+package com.uber.jenkins.phabricator.coverage;
+
+import hudson.plugins.cobertura.Ratio;
+import hudson.plugins.cobertura.targets.CoverageMetric;
+import hudson.plugins.cobertura.targets.CoverageResult;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+public class CoberturaPluginCoverageProviderTest {
+
+    @Test
+    public void conversion() {
+        CoverageResult result = getMockResult();
+        CodeCoverageMetrics metrics = CoberturaPluginCoverageProvider.convertCobertura(result);
+        assertEquals(75.0f, metrics.getLineCoveragePercent(), 0.0f);
+        assertEquals(0.0f, metrics.getPackageCoveragePercent(), 0.0f);
+    }
+
+    private CoverageResult getMockResult() {
+        Ratio ratio = Ratio.create(75.0f, 100.0f);
+        CoverageResult result = mock(CoverageResult.class);
+        when(result.getCoverage(CoverageMetric.LINE)).thenReturn(ratio);
+        return result;
+    }
+}

--- a/src/test/java/com/uber/jenkins/phabricator/coverage/JacocoCoverageProviderTest.java
+++ b/src/test/java/com/uber/jenkins/phabricator/coverage/JacocoCoverageProviderTest.java
@@ -1,0 +1,37 @@
+package com.uber.jenkins.phabricator.coverage;
+
+import hudson.plugins.jacoco.model.Coverage;
+import hudson.plugins.jacoco.report.CoverageReport;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@PrepareForTest({CoverageReport.class})
+@RunWith(PowerMockRunner.class)
+public class JacocoCoverageProviderTest {
+
+    @Test
+    public void conversion() {
+        CoverageReport result = getMockResult();
+        CodeCoverageMetrics metrics = JacocoPluginCoverageProvider.convertJacoco(result);
+        assertEquals(60.0f, metrics.getMethodCoveragePercent(), 0.1f);
+        assertEquals(80.0f, metrics.getClassesCoveragePercent(), 0.1f);
+        assertEquals(75.0f, metrics.getLineCoveragePercent(), 0.1f);
+        assertEquals(50.0f, metrics.getConditionalCoveragePercent(), 0.1f);
+    }
+
+    private CoverageReport getMockResult() {
+        CoverageReport report = PowerMockito.mock(CoverageReport.class);
+        when(report.getMethodCoverage()).thenReturn(new Coverage(40, 60));
+        when(report.getClassCoverage()).thenReturn(new Coverage(20, 80));
+        when(report.getLineCoverage()).thenReturn(new Coverage(25, 75));
+        when(report.getBranchCoverage()).thenReturn(new Coverage(50, 50));
+        when(report.hasLineCoverage()).thenReturn(true);
+        return report;
+    }
+}


### PR DESCRIPTION
- Use the cobertura/jacoco Jenkins plugin reports where available and only fallback to xml parsing when no plugins are applied for the uberalls coverage metrics
- Line coverage info is still computed via xml parsing
- This would preserve the previous plugin behavior and lead to less regressions/bugs
- It seems there are quite a few edge cases when the current coverage reporting breaks when coverage is not aggregated into a single file as part of the build