### PR TITLE
Create PhabricatorBuildStartNotifier plugin

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -87,11 +87,23 @@ Pipeline
 Typically the Phabricator Notifier is used as a reporting step in a Jenkins Pipeline. The test result collector step must be run before the Notifier.
 
 ```groovy
-stage ('report') {
-    //...
-    // junit()
-    step([$class: 'PhabricatorNotifier', commentOnSuccess: true, commentWithConsoleLinkOnFailure: true])
-    //...
-}
+
+  stages {
+    stage('create link') {
+      steps {
+        // Create the "Jenkins" link on the harbormaster artifact.
+        step([$class: 'PhabricatorBuildStartNotifier'])
+      }
+    }  
+    stage ('build') {
+        // ...
+    }
+  }
+  post {
+    always {
+      step([$class: 'PhabricatorNotifier', commentOnSuccess: false, commentWithConsoleLinkOnFailure: true])
+    }
+  }
+
 
 ```

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildStartNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildStartNotifier.java
@@ -1,0 +1,76 @@
+package com.uber.jenkins.phabricator;
+
+import com.uber.jenkins.phabricator.conduit.ConduitAPIClient;
+import com.uber.jenkins.phabricator.conduit.ConduitAPIException;
+import com.uber.jenkins.phabricator.conduit.DifferentialClient;
+import com.uber.jenkins.phabricator.credentials.ConduitCredentials;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+
+import java.io.IOException;
+import javax.annotation.Nonnull;
+
+import jenkins.tasks.SimpleBuildStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * When using the Jenkins pipeline it doesn't make any sense to use BuildWrapper to start the
+ * build. However, it is still useful to have something send the harbormaster URI at the
+ * start of the build.
+ */
+public class PhabricatorBuildStartNotifier extends Publisher implements SimpleBuildStep {
+
+    @DataBoundConstructor
+    public PhabricatorBuildStartNotifier() { }
+
+    @Override
+    public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace,
+                        @Nonnull Launcher launcher, @Nonnull TaskListener listener)
+            throws InterruptedException, IOException {
+        EnvVars environment = build.getEnvironment(listener);
+        final String diffID = environment.get(PhabricatorPlugin.DIFFERENTIAL_ID_FIELD);
+        final String phid = environment.get(PhabricatorPlugin.PHID_FIELD);
+        ConduitAPIClient conduitClient = getConduitClient(build.getParent());
+        DifferentialClient diffClient = new DifferentialClient(diffID, conduitClient);
+        String buildUrl;
+        if (getDescriptor().getIsBlueOceanEnabled()) {
+            buildUrl = environment.get("RUN_DISPLAY_URL");
+        } else {
+            buildUrl = environment.get("BUILD_URL");
+        }
+        try {
+            diffClient.sendHarbormasterUri(phid, buildUrl);
+        } catch (ConduitAPIException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    // Overridden for better type safety.
+    @Override
+    public PhabricatorBuildStartNotifierDescriptor getDescriptor() {
+        return (PhabricatorBuildStartNotifierDescriptor) super.getDescriptor();
+    }
+
+    private ConduitCredentials getConduitCredentials(Job owner) {
+        return getDescriptor().getCredentials(owner);
+    }
+
+    private ConduitAPIClient getConduitClient(Job owner) {
+        ConduitCredentials credentials = getConduitCredentials(owner);
+        if (credentials == null) {
+            throw new RuntimeException("No credentials configured for conduit");
+        }
+        return new ConduitAPIClient(credentials.getGateway(), credentials.getToken().getPlainText());
+    }
+}

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildStartNotifierDescriptor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildStartNotifierDescriptor.java
@@ -1,0 +1,78 @@
+package com.uber.jenkins.phabricator;
+
+import com.uber.jenkins.phabricator.credentials.ConduitCredentials;
+import com.uber.jenkins.phabricator.utils.CommonUtils;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Publisher;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+@SuppressWarnings("UnusedDeclaration")
+@Extension
+public final class PhabricatorBuildStartNotifierDescriptor extends BuildStepDescriptor<Publisher> {
+
+    private String credentialsID;
+    private String uberallsURL;
+    private boolean isBlueOceanEnabled;
+
+    public PhabricatorBuildStartNotifierDescriptor() {
+        super(PhabricatorBuildStartNotifier.class);
+        load();
+    }
+
+    public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+        // Indicates that this builder can be used with all kinds of project types
+        return true;
+    }
+
+    /**
+     * This human readable name is used in the configuration screen.
+     */
+    public String getDisplayName() {
+        return "Post to Phabricator, Build Starting";
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+        // To persist global configuration information, set that to properties and call save().
+        req.bindJSON(this, formData.getJSONObject("phabstart"));
+        save();
+        return super.configure(req, formData);
+    }
+
+    @SuppressWarnings("unused")
+    public ListBoxModel doFillCredentialsIDItems(
+            @AncestorInPath Jenkins context,
+            @QueryParameter String remoteBase) {
+        return ConduitCredentialsDescriptor.doFillCredentialsIDItems(
+                context);
+    }
+
+    public ConduitCredentials getCredentials(Job owner) {
+        // This will always grab the credentials ID.
+        return ConduitCredentialsDescriptor.getCredentials(owner, credentialsID);
+    }
+
+    public String getCredentialsID() {
+        return credentialsID;
+    }
+
+    public void setCredentialsID(String credentialsID) {
+        this.credentialsID = credentialsID;
+    }
+
+    public boolean getIsBlueOceanEnabled() {
+        return isBlueOceanEnabled;
+    }
+
+    public void setIsBlueOceanEnabled(boolean value) {
+        isBlueOceanEnabled = value;
+    }
+}

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildStartNotifier/config.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildStartNotifier/config.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <!-- No need for per-project configuration -->
+</j:jelly>

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildStartNotifier/global.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildStartNotifier/global.jelly
@@ -1,0 +1,29 @@
+<?jelly escape-by-default='true'?>
+<j:jelly
+        xmlns:j="jelly:core"
+        xmlns:f="/lib/form"
+        xmlns:c="/lib/credentials">
+  <!--
+    This Jelly script is used to produce the global configuration option.
+
+    Jenkins uses a set of tag libraries to provide uniformity in forms.
+    To determine where this tag is defined, first check the namespace URI,
+    and then look under $JENKINS/views/. For example, <f:section> is defined
+    in $JENKINS/views/lib/form/section.jelly.
+
+    It's also often useful to just check other similar scripts to see what
+    tags they use. Views are always organized according to its owner class,
+    so it should be straightforward to find them.
+  -->
+  <f:section title="Phabricator Build Start Notification" name="phabstart">
+    <f:optionalBlock>
+      <f:entry title="Default Phabricator Credentials" field="credentialsID" description="Conduit URI and Token">
+        <c:select />
+      </f:entry>
+      <f:entry title="Blue Ocean URI's" field="isBlueOceanEnabled"
+               description="Make use of Blue Ocean URI's in notifications posted to Phabricator">
+        <f:checkbox default="false" />
+      </f:entry>
+    </f:optionalBlock>
+  </f:section>
+</j:jelly>


### PR DESCRIPTION
**What problems does this solve?**
If you are using a `Jenkinsfile`, you can use `PhabricatorNotifier` to notify phab after the build finishes. However, since `PhabricatorBuildWrapper` isn't supported in `Jenkinsfiles` (and probably never should be) nothing notifies phabricator about which URI to display when the build finishes. Ie, below the "Jenkins" text won't appear until the build is fully complete.

![screen shot 2019-02-20 at 10 50 10 pm](https://user-images.githubusercontent.com/549900/53149600-01d0b400-3563-11e9-9049-13c8d15a8dde.png)


This is frustrating for engineers who want to quickly check the status of their harbormaster build.

**How does this address it**
Create a new `PhabricatorBuildStartNotifier` that you can execute at the beginning of your `Jenkinsfile` like follows

```
stage('create link') {
  steps{
    step([$class: 'PhabricatorBuildStartNotifier'])
  }
}
```

**Alternatives Considered**
I could just ask all engineers to add the following snippet at the top of their `Jenkinsfile`

```
stage('Create Link') {
  environment {
    CONDUIT_TOKEN = credentials("conduit-token-dev2")
  }
  steps {
    sh """echo '{ "buildTargetPHID": "$PHID", "artifactKey": "jenkins.uri", "artifactType": "uri",
      "artifactData": { "uri": "$BUILD_URL", "name": "Jenkins", "ui.external": true }
    }' | arc call-conduit --conduit-uri https://phabricator.cloudkitchens.internal/ --conduit-token $CONDUIT_TOKEN harbormaster.createartifact"""
  }
}
```

However, this exposes an implementation detail of the Jenkins plugin, that `artifactKey=jenkins.uri`. Plus, this is a bit cumbersome. 

