### PR TITLE
perform method signature update

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifier.java
@@ -119,7 +119,7 @@ public class PhabricatorNotifier extends Notifier implements SimpleBuildStep {
     }
 
     @Override
-    public final void perform(
+    public void perform(
             final Run<?, ?> build, FilePath workspace, final Launcher launcher,
             final TaskListener listener) throws InterruptedException, IOException {
         EnvVars environment = build.getEnvironment(listener);


### PR DESCRIPTION
Hopefully sorts `java.lang.IllegalArgumentException` which is being thrown as of Jenkins 2.242:

```
java.lang.IllegalArgumentException: Method perform not found in com.uber.jenkins.phabricator.PhabricatorNotifier (or it is private, final or static)
	at hudson.Util.getMethod(Util.java:1462)
	at hudson.Util.isOverridden(Util.java:1439)
	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:110)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:78)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:741)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:690)
	at hudson.model.Build$BuildExecution.post2(Build.java:186)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:635)
	at hudson.model.Run.execute(Run.java:1905)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:428)
```

Thanks!
