### PR TITLE
use Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       env: TASKS="cobertura coveralls"
 
 script:
-  - ./gradlew clean $TASKS --no-daemon
+  - ./gradlew clean $TASKS
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
